### PR TITLE
UX improvements to docs menu

### DIFF
--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,7 +1,8 @@
 {{/* Prefix values for labels */}}
 {{ $docLabel := "Documentation " }}
 {{ $releaseLabel := "Release: " }}
-{{ $preRelLabel := "Pre-release" }}
+{{ $mstMainLabel := "Pre-release" }}
+{{ $mstDropLabel := "development" }}
 
 {{/* set defaults for version and dropdown menu highlighting */}}
 {{ $.Scratch.Set "activeVersion" .Site.Params.version }}
@@ -18,9 +19,9 @@
   {{ if eq $curPage $docVerURL }}
     {{ $.Scratch.Set "docsVer" .version }}
     {{ $.Scratch.Set "activeVersion" .version }}
-  {{/* if not a released version (master branch), use $preRelLabel */}}
-  {{ else if eq $curPage "development" }}
-    {{ $.Scratch.Set "docsVer" $preRelLabel }}
+  {{/* if not a released version (master branch), use $mstMainLabel */}}
+  {{ else if eq $curPage $mstDropLabel }}
+    {{ $.Scratch.Set "docsVer" $mstMainLabel }}
     {{ $.Scratch.Set "activeVersion" .version }}
   {{ end }}
 {{ end }}
@@ -30,6 +31,8 @@
 </a>
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
   {{ range .Site.Params.versions }}
-  <a class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active" style="color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
+  <a
+  class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active{{ end }}"
+  style="{{ if eq .version $mstDropLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
   {{ end }}
 </div>

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,20 +1,35 @@
+{{/* Prefix values for labels */}}
+{{ $docLabel := "Documentation " }}
+{{ $releaseLabel := "Release: " }}
+{{ $preRelLabel := "Pre-release" }}
+
+{{/* set defaults for version and dropdown menu highlighting */}}
 {{ $.Scratch.Set "activeVersion" .Site.Params.version }}
-{{ $.Scratch.Set "currDocsVer" "Release: Latest" }}
+{{ $.Scratch.Set "docsVer" .Site.Params.version }}
+
+{{/* retrieve current page */}}
 {{ $curPage := .Page.Section }}
+
+{{/* generate menu from config/params.toml */}}
 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 {{ range .Site.Params.versions }}
-  {{ $docsVersions := ( printf "%s%s" .version "-docs" | printf "%s" ) }}
-  {{ if eq $curPage $docsVersions }}
-  {{ $.Scratch.Set "currDocsVer" ( printf "%s%s" "Release: " .version | printf "%s" ) }}
+  {{/* create "v##-docs" value to check against URLs */}}
+  {{ $docVerURL := ( printf "%s%s" .version "-docs" | printf "%s" ) }}
+  {{ if eq $curPage $docVerURL }}
+    {{ $.Scratch.Set "docsVer" .version }}
     {{ $.Scratch.Set "activeVersion" .version }}
+  {{/* if not a released version (master branch), use $preRelLabel */}}
   {{ else if eq $curPage "development" }}
-    {{ $.Scratch.Set "currDocsVer" "Pre-release" }}
+    {{ $.Scratch.Set "docsVer" $preRelLabel }}
     {{ $.Scratch.Set "activeVersion" .version }}
   {{ end }}
 {{ end }}
-<span>{{ $.Scratch.Get "currDocsVer" }}</span></a>
+  {{/* generate menu */}}
+  <span class="d-none d-lg-inline d-xl-inline">{{ ( printf "%s%s" $docLabel ( $.Scratch.Get "docsVer" ) | printf "%s" ) }}</span>
+  <span class="d-none d-sm-inline d-md-inline d-lg-none d-xl-none">{{ ( printf "%s%s" $releaseLabel ( $.Scratch.Get "docsVer" ) | printf "%s" ) }}</span>
+</a>
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
   {{ range .Site.Params.versions }}
-  <a class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active{{ end }}" href="{{ .url }}">{{ .version }}</a>
+  <a class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active" style="color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
   {{ end }}
 </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,36 +1,36 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
-	<a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     <span class="navbar-logo">{{ with resources.Get "/icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }} {{ end }}</span>
     <span class="brand-name font-weight-bold">{{ .Site.Title }}</span>
-	</a>
-	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
-		<ul class="navbar-nav mt-2 mt-lg-0">
-			{{ if or (eq .Page.Section "blog") (eq .Page.Section "community") (eq .Page.Section "contributing") }}
-			<li class="nav-item mr-4 mb-2 mb-lg-0">
-	    	<a class="nav-link" href="../docs/"><span>Documentation</span></a>
-			</li>
-    	{{ else }}
-		  <li class="nav-item dropdown d-none d-lg-block">
-				{{ partial "navbar-version-selector.html" . }}
-		  </li>
-			{{ end }}
-			{{ $p := . }}
-			{{ range .Site.Menus.main }}
-			<li class="nav-item mr-4 mb-2 mb-lg-0">
-				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
-				{{ with .Page }}
-				{{ $active = or $active ( $.IsDescendant .)  }}
-				{{ end }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
-			</li>
-     			{{ end }}
-			{{ if  (gt (len .Site.Home.Translations) 1) }}
-			<li class="nav-item dropdown d-none d-lg-block">
-				{{ partial "navbar-lang-selector.html" . }}
-			</li>
-			{{ end }}
-		</ul>
-	</div>
-	<div class="navbar-nav d-none d-xl-block">{{ partial "search-input.html" . }}</div>
+  </a>
+  <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+    <ul class="navbar-nav mt-2 mt-lg-0">
+      {{ if or (eq .Page.Section "blog") (eq .Page.Section "community") (eq .Page.Section "contributing") (eq .Page.Section "") }}
+      <li class="nav-item mr-4 mb-2 mb-lg-0">
+        <a class="nav-link" href="../docs/"><span>Documentation</span></a>
+      </li>
+      {{ else }}
+      <li class="nav-item dropdown d-none d-lg-block">
+        {{ partial "navbar-version-selector.html" . }}
+      </li>
+      {{ end }}
+      {{ $p := . }}
+      {{ range .Site.Menus.main }}
+      <li class="nav-item mr-4 mb-2 mb-lg-0">
+        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
+        {{ with .Page }}
+        {{ $active = or $active ( $.IsDescendant .)  }}
+        {{ end }}
+        <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+      </li>
+      {{ end }}
+      {{ if  (gt (len .Site.Home.Translations) 1) }}
+      <li class="nav-item dropdown d-none d-lg-block">
+        {{ partial "navbar-lang-selector.html" . }}
+      </li>
+      {{ end }}
+    </ul>
+  </div>
+  <div class="navbar-nav d-none d-xl-block">{{ partial "search-input.html" . }}</div>
 </nav>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,11 +6,15 @@
 	</a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">
-			
-		      <li class="nav-item dropdown d-none d-lg-block">
-			{{ partial "navbar-version-selector.html" . }}
-		      </li>
-			
+			{{ if or (eq .Page.Section "blog") (eq .Page.Section "community") (eq .Page.Section "contributing") }}
+			<li class="nav-item mr-4 mb-2 mb-lg-0">
+	    	<a class="nav-link" href="../docs/"><span>Documentation</span></a>
+			</li>
+    	{{ else }}
+		  <li class="nav-item dropdown d-none d-lg-block">
+				{{ partial "navbar-version-selector.html" . }}
+		  </li>
+			{{ end }}
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
 			<li class="nav-item mr-4 mb-2 mb-lg-0">

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -8,9 +8,11 @@
     </button>
   </form>
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
+    {{ if or (ne .Page.Section "blog") (ne .Page.Section "community") (ne .Page.Section "contributing") }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-version-selector.html" . }}
     </div>
+    {{ end }}
     {{ if  (gt (len .Site.Home.Translations) 1) }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}


### PR DESCRIPTION
- Show "Documentation v##" in main menu - only in "Docs" section
- Otherwise, show "Documentation" (default to latest version) - ie Blog, Community, Contributing sections
- In reduced mobile view, show "Release: v##" in menu (to ensure version is visible - awareness)
- Grey "development" item in dropdown list to reduce priority

fixes: #17 