### PR TITLE
global params and other fixes

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,49 +9,78 @@ apache_license = "https://www.apache.org/licenses/LICENSE-2.0"
 # GitHub repository
 github_repo = "https://github.com/knative/docs"
 
-# Default values (Latest Knative docs release)
+
+# Non-docs params
+# Content section path values. The directory folder of the other
+# non-docs sections that appear in the main nav bar (site banner).
+sec_blog = "blog"
+sec_community = "community"
+sec_contrib = "contributing"
+
+# Pre-release section path value ("master" docs directory folder)
+master = "development"
+
+# Default docs params
+# Latest Knative docs release/version - Default values (for Docsy Template)
 # Default GitHub branch
 github_branch = "release-0.4"
 # Default website version
 version = "v0.4"
 
-# Product versions
-
+# Doc versions params
 # Create a separate [[versions]] set for every version / doc set branch
 # Use the ghbranchname param for specifying the GitHub branchname ->
 # Example: [thisisalink](https://github.com/..../tree/{{< params "ghbranchname" >}}/....)
+#
+# [[versions]] - Defines a single "version" of the Knative docs
+#   version - Intuitive version label (ie. visible in menus)
+#   ghbranchname - Name of branch of the doc version in GitHub (https://github.com/knative/docs/branches)
+#   url - Fully qualified website URL to the doc version (ie. https://www.knative.dev/[dirpath])
+#   dirpath - The content folder name of the doc version
+#           - Latest release is always set to "docs"
+#           - Past/archived releases change to "v#.#-docs",
+#             where # is the MAJOR and MINOR semantic version values
 
+# Latest version
+# Set to "docs" path
 [[versions]]
   version = "v0.4"
   ghbranchname = "release-0.4"
   url = "https://www.knative.dev/docs/"
+  dirpath = "docs"
 
-# Past versions
+# Archived versions
+# Prefix all past versions with release # "v#.#-docs"
 [[versions]]
   version = "v0.3"
   ghbranchname = "release-0.3"
   url = "https://www.knative.dev/v0.3-docs/"
+  dirpath = "v0.3-docs"
 
 [[versions]]
   version = "v0.2"
   ghbranchname = "release-0.2"
   url = "https://github.com/knative/docs/tree/release-0.2"
+  dirpath = "github-repo"
 
 [[versions]]
   version = "v0.1"
   ghbranchname = "release-0.1"
   url = "https://github.com/knative/docs/tree/release-0.1"
+  dirpath = "github-repo"
 
+# In-development (pre-release) content - "master" branch
 [[versions]]
   version = "development"
   ghbranchname = "master"
   url = "https://www.knative.dev/development/"
+  dirpath = "development"
 
 
 # User interface configuration
 [ui]
-# Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+# Set to true to display the nav bar in compact state (collapse menu).
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,8 +1,8 @@
-{{/* Prefix values for labels */}}
-{{ $docLabel := "Documentation " }}
-{{ $releaseLabel := "Release: " }}
-{{ $mstMainLabel := "Pre-release" }}
-{{ $mstDropLabel := "development" }}
+{{/* Prefix labels for menus */}}
+{{ $.Scratch.Set "docLabel" "Documentation " }}
+{{ $.Scratch.Set "releaseLabel" "Release: " }}
+{{ $masterMainLabel := "Pre-release" }}
+{{ $masterDropLabel := .Site.Params.master }}
 
 {{/* set defaults for version and dropdown menu highlighting */}}
 {{ $.Scratch.Set "activeVersion" .Site.Params.version }}
@@ -14,25 +14,33 @@
 {{/* generate menu from config/params.toml */}}
 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 {{ range .Site.Params.versions }}
-  {{/* create "v##-docs" value to check against URLs */}}
-  {{ $docVerURL := ( printf "%s%s" .version "-docs" | printf "%s" ) }}
-  {{ if eq $curPage $docVerURL }}
-    {{ $.Scratch.Set "docsVer" .version }}
-    {{ $.Scratch.Set "activeVersion" .version }}
-  {{/* if not a released version (master branch), use $mstMainLabel */}}
-  {{ else if eq $curPage $mstDropLabel }}
-    {{ $.Scratch.Set "docsVer" $mstMainLabel }}
+  {{ if eq $curPage .dirpath }}
+
+    {{ if eq $curPage $masterDropLabel }}
+      {{/* pre-release content (master branch) */}}
+      {{ $.Scratch.Set "docLabel" $masterMainLabel }}
+      {{ $.Scratch.Set "releaseLabel" $masterMainLabel }}
+    {{ else }}
+      {{/* released version */}}
+      {{ $.Scratch.Add "docLabel" " " }}
+      {{ $.Scratch.Add "docLabel" .version }}
+      {{ $.Scratch.Set "docsVer" .version }}
+      {{ $.Scratch.Add "releaseLabel" " " }}
+      {{ $.Scratch.Add "releaseLabel" .version }}
+    {{ end }}
+
     {{ $.Scratch.Set "activeVersion" .version }}
   {{ end }}
 {{ end }}
-  {{/* generate menu */}}
-  <span class="d-none d-lg-inline d-xl-inline">{{ ( printf "%s%s" $docLabel ( $.Scratch.Get "docsVer" ) | printf "%s" ) }}</span>
-  <span class="d-sm-inline d-md-inline d-lg-none d-xl-none">{{ ( printf "%s%s" $releaseLabel ( $.Scratch.Get "docsVer" ) | printf "%s" ) }}</span>
+  {{/* set current version label */}}
+  <span class="d-none d-lg-inline d-xl-inline">{{ printf "%s" ($.Scratch.Get "docLabel") }}</span>
+  <span class="d-sm-inline d-md-inline d-lg-none d-xl-none">{{ printf "%s" ($.Scratch.Get "releaseLabel") }}</span>
 </a>
+{{/* generate dropdown menu */}}
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
   {{ range .Site.Params.versions }}
   <a
   class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active{{ end }}"
-  style="{{ if eq .version $mstDropLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
+  style="{{ if eq .version $masterDropLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
   {{ end }}
 </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,7 +6,7 @@
   </a>
   <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
     <ul class="navbar-nav mt-2 mt-lg-0">
-      {{ if or (eq .Page.Section "blog") (eq .Page.Section "community") (eq .Page.Section "contributing") (eq .Page.Section "") }}
+      {{ if or (eq .Page.Section .Site.Params.secblog) (eq .Page.Section .Site.Params.seccommunity) (eq .Page.Section .Site.Params.seccontrib) (eq .Page.Section "") }}
       <li class="nav-item mr-4 mb-2 mb-lg-0">
         <a class="nav-link" href="../docs/"><span>Documentation</span></a>
       </li>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,16 +1,33 @@
 
 {{ if .Path }}
-{{ $gh_repo := ($.Param "github_repo") }}
-{{ $gh_branch := ($.Param "github_branch") }}
-{{ if $gh_repo }}
-{{ if $gh_branch }}
-<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/%s/%s" $gh_repo $gh_branch .Path }}
-{{ $issuesURL := printf "%s/issues/new?title=%s(%s)&labels=kind%2Fbug&template=bug-in-existing-docs.md" $gh_repo (htmlEscape $.Title) (htmlEscape $.Path)}}
-<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-</div>
-{{ end }}
-{{ end }}
-{{ end }}
+  {{ $pageSection := .Page.Section }}
+  {{ $.Scratch.Set "filepath" .Path }}
+  {{ if eq (printf "%s" .File) "_index" }}
+    {{ $.Scratch.Set "filepath" (replace (printf "%s" .Path) "_index" "README") }}
+  {{ end }}
+  {{ if ne $pageSection "docs" }}
+    {{ $.Scratch.Set "filepath" (replaceRE "v[0-9].[0-9]-docs" "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
+  {{ end }}
+  {{ if eq $pageSection .Site.Params.master }}
+    {{ $.Scratch.Set "filepath" (replaceRE "development" "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
+  {{ end }}
 
+  {{ $.Scratch.Set "gh_branch" ($.Param "github_branch") }}
+  {{ range .Site.Params.versions }}
+    {{ if eq $pageSection .dirpath }}
+      {{ $.Scratch.Set "gh_branch" .ghbranchname }}
+    {{ end }}
+  {{ end }}
+
+  {{ $gh_repo := ($.Param "github_repo") }}
+
+  {{ if $gh_repo }}
+    <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+    {{ $editURL := printf "%s/edit/%s/%s" $gh_repo ($.Scratch.Get "gh_branch") ($.Scratch.Get "filepath") }}
+    {{ $issuesURL := printf "%s/issues/new?title=%s(%s)&labels=kind%2Fbug&template=bug-in-existing-docs.md" $gh_repo (htmlEscape $.Title) (htmlEscape $.Path)}}
+    <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+    <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+    </div>
+  {{ end }}
+
+{{ end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -8,7 +8,7 @@
     </button>
   </form>
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
-    {{ if or (ne .Page.Section "blog") (ne .Page.Section "community") (ne .Page.Section "contributing") }}
+    {{ if or (ne .Page.Section .Site.Params.secblog) (ne .Page.Section .Site.Params.seccommunity) (ne .Page.Section .Site.Params.seccontrib) }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-version-selector.html" . }}
     </div>


### PR DESCRIPTION
- fix "edit in GitHub" link to target the "docs" folder in the correct branch
- created and implement global variables (improve label maintenance)
- correct the dropdown menu label for the "development" portion of the site (remove "Documentation" prefix)
- left nav menu behavior fix -> all sections closed by default

fixes: #18 