### PR TITLE
Fix link to "Documentation" from other sections

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,14 +9,6 @@ apache_license = "https://www.apache.org/licenses/LICENSE-2.0"
 # GitHub repository
 github_repo = "https://github.com/knative/docs"
 
-
-# Non-docs params
-# Content section path values. The directory folder of the other
-# non-docs sections that appear in the main nav bar (site banner).
-sec_blog = "blog"
-sec_community = "community"
-sec_contrib = "contributing"
-
 # Pre-release section path value ("master" docs directory folder)
 master = "development"
 
@@ -30,12 +22,15 @@ version = "v0.5"
 # Doc versions params
 # Create a separate [[versions]] set for every version / doc set branch
 # Use the ghbranchname param for specifying the GitHub branchname ->
-# Example: [thisisalink](https://github.com/..../tree/{{< params "ghbranchname" >}}/....)
+# Example:
+#   [thisisalink](https://github.com/.../tree/{{< params "ghbranchname" >}}/...)
 #
 # [[versions]] - Defines a single "version" of the Knative docs
 #   version - Intuitive version label (ie. visible in menus)
-#   ghbranchname - Name of branch of the doc version in GitHub (https://github.com/knative/docs/branches)
-#   url - Fully qualified website URL to the doc version (ie. https://www.knative.dev/[dirpath])
+#   ghbranchname - Name of branch of the doc version in GitHub
+#                  (https://github.com/knative/docs/branches)
+#   url - Fully qualified website URL to the doc version
+#         (ie. https://www.knative.dev/[dirpath])
 #   dirpath - The content folder name of the doc version
 #           - Latest release is always set to "docs"
 #           - Past/archived releases change to "v#.#-docs",

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,24 +6,23 @@
   </a>
   <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
     <ul class="navbar-nav mt-2 mt-lg-0">
-      {{ if or (eq .Page.Section .Site.Params.sec_blog) (eq .Page.Section .Site.Params.sec_community) (eq .Page.Section .Site.Params.sec_contrib) (eq .Page.Section "") }}
-      <li class="nav-item mr-4 mb-2 mb-lg-0">
-        <a class="nav-link" href="../docs/"><span>Documentation</span></a>
-      </li>
-      {{ else }}
+      {{/* Display doc version selector menu for "docs" or "v#.#-docs" sections */}}
+      {{ if in .Page.Section "docs" }}
       <li class="nav-item dropdown d-none d-lg-block">
         {{ partial "navbar-version-selector.html" . }}
       </li>
       {{ end }}
       {{ $p := . }}
       {{ range .Site.Menus.main }}
-      <li class="nav-item mr-4 mb-2 mb-lg-0">
         {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
         {{ with .Page }}
-        {{ $active = or $active ( $.IsDescendant .)  }}
+        {{ $active = or $active ( $.IsDescendant .) }}
         {{ end }}
-        <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
-      </li>
+        {{/* Skip adding "Documentation" when version selector is added */}}
+        {{ if or (not (in $p.Section "docs")) (ne .Name "Documentation" ) }}
+        <li class="nav-item mr-4 mb-2 mb-lg-0">
+          <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+        {{ end }}
       {{ end }}
       {{ if  (gt (len .Site.Home.Translations) 1) }}
       <li class="nav-item dropdown d-none d-lg-block">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -19,7 +19,7 @@
         {{ $active = or $active ( $.IsDescendant .) }}
         {{ end }}
         {{/* Skip adding "Documentation" when version selector is added */}}
-        {{ if or (not (in $p.Section "docs")) (ne .Name "Documentation" ) }}
+        {{ if or (not (in $p.Section "docs")) (ne .Name "Documentation") }}
         <li class="nav-item mr-4 mb-2 mb-lg-0">
           <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
         {{ end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -8,7 +8,7 @@
     </button>
   </form>
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
-    {{ if or (ne .Page.Section .Site.Params.sec_blog) (ne .Page.Section .Site.Params.sec_community) (ne .Page.Section .Site.Params.sec_contrib) }}
+    {{ if in .Page.Section "docs" }}
     <div class="nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-version-selector.html" . }}
     </div>


### PR DESCRIPTION
Noticed that the "Documentation" link in the main menu is broken on child pages of any peer section (Community, Blog, or Contributing).

Also found and used a more reliable conditional (`if in`) which rendered the directory path variables useless (so removed those too) 

Related change: https://github.com/knative/docs/pull/1161

Staged in my fork at: https://websiteinfra2--knative-v1.netlify.com/