### PR TITLE
add v0.5 docs to website

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -23,9 +23,9 @@ master = "development"
 # Default docs params
 # Latest Knative docs release/version - Default values (for Docsy Template)
 # Default GitHub branch
-github_branch = "release-0.4"
+github_branch = "release-0.5"
 # Default website version
-version = "v0.4"
+version = "v0.5"
 
 # Doc versions params
 # Create a separate [[versions]] set for every version / doc set branch
@@ -42,15 +42,25 @@ version = "v0.4"
 #             where # is the MAJOR and MINOR semantic version values
 
 # Latest version
+################
 # Set to "docs" path
+
 [[versions]]
-  version = "v0.4"
-  ghbranchname = "release-0.4"
+  version = "v0.5"
+  ghbranchname = "release-0.5"
   url = "https://www.knative.dev/docs/"
   dirpath = "docs"
 
 # Archived versions
+###################
 # Prefix all past versions with release # "v#.#-docs"
+
+[[versions]]
+  version = "v0.4"
+  ghbranchname = "release-0.4"
+  url = "https://www.knative.dev/v0.4-docs/"
+  dirpath = "v0.4-docs"
+
 [[versions]]
   version = "v0.3"
   ghbranchname = "release-0.3"
@@ -69,7 +79,10 @@ version = "v0.4"
   url = "https://github.com/knative/docs/tree/release-0.1"
   dirpath = "github-repo"
 
+# Pre-release version
+###################
 # In-development (pre-release) content - "master" branch
+
 [[versions]]
   version = "development"
   ghbranchname = "master"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Set default branch (latest docs release)
-DEFAULTBRANCH="release-0.4"
+DEFAULTBRANCH="release-0.5"
 BRANCH="$DEFAULTBRANCH"
 
 # Get and use specified branch name otherwise, use default (latest release)
@@ -84,6 +84,8 @@ git clone -b "$BRANCH" https://github.com/knative/docs.git temp/release/latest
 # Only copy and keep the "docs" folder from all branched releases:
 mv temp/release/latest/docs content/en/docs
 echo 'Getting the archived docs releases'
+git clone -b "release-0.4" https://github.com/knative/docs.git temp/release/v0.4
+mv temp/release/v0.4/docs content/en/v0.4-docs
 git clone -b "release-0.3" https://github.com/knative/docs.git temp/release/v0.3
 mv temp/release/v0.3/docs content/en/v0.3-docs
 # Delete temp directory (clear out old copies of shared content: blog, contributing, community)


### PR DESCRIPTION
Add the v0.5 release to knative.dev build (https://github.com/knative/docs/releases/tag/v0.5.x)

Fixes: https://github.com/knative/docs/issues/1138