### PR TITLE
fix non docs link to github

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -10,12 +10,12 @@ apache_license = "https://www.apache.org/licenses/LICENSE-2.0"
 github_repo = "https://github.com/knative/docs"
 
 # Pre-release section path value ("master" docs directory folder)
-master = "development"
+masterfolder = "development"
 
 # Default docs params
 # Latest Knative docs release/version - Default values (for Docsy Template)
 # Default GitHub branch
-github_branch = "release-0.5"
+latest_github_branch = "release-0.5"
 # Default website version
 version = "v0.5"
 

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -2,7 +2,7 @@
 {{ $.Scratch.Set "docLabel" "Documentation " }}
 {{ $.Scratch.Set "releaseLabel" "Release: " }}
 {{ $masterMainLabel := "Pre-release" }}
-{{ $masterDropLabel := .Site.Params.master }}
+{{ $masterDropLabel := .Site.Params.masterfolder }}
 
 {{/* set defaults for version and dropdown menu highlighting */}}
 {{ $.Scratch.Set "activeVersion" .Site.Params.version }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,5 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
+{{ $master := .Site.Params.masterfolder}}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     <span class="navbar-logo">{{ with resources.Get "/icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }} {{ end }}</span>
@@ -7,7 +8,7 @@
   <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
     <ul class="navbar-nav mt-2 mt-lg-0">
       {{/* Display doc version selector menu for "docs" or "v#.#-docs" sections */}}
-      {{ if in .Page.Section "docs" }}
+      {{ if or (in .Page.Section "docs") (in .Page.Section $master) }}
       <li class="nav-item dropdown d-none d-lg-block">
         {{ partial "navbar-version-selector.html" . }}
       </li>
@@ -19,7 +20,14 @@
         {{ $active = or $active ( $.IsDescendant .) }}
         {{ end }}
         {{/* Skip adding "Documentation" when version selector is added */}}
-        {{ if or (not (in $p.Section "docs")) (ne .Name "Documentation") }}
+        {{ $.Scratch.Set "showdoclink" "true"}}
+        {{ if and (in $p.Section "docs") (eq .Name "Documentation") }}
+        	{{ $.Scratch.Set "showdoclink" "false"}}
+        {{ end }}
+        {{ if and (eq $p.Section $master) (eq .Name "Documentation") }}
+        	{{ $.Scratch.Set "showdoclink" "false"}}
+        {{ end }}
+        {{ if eq (printf "%s" ($.Scratch.Get "showdoclink")) "true" }}
         <li class="nav-item mr-4 mb-2 mb-lg-0">
           <a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
         {{ end }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,27 +1,37 @@
 
+{{ $master := .Site.Params.masterfolder }}
 {{ if .Path }}
   {{ $pageSection := .Page.Section }}
   {{ $.Scratch.Set "filepath" .Path }}
+  {{ $.Scratch.Set "gh_branch" ($.Param "latest_github_branch") }}
+  {{ $gh_repo := ($.Param "github_repo") }}
+
+  {{/* Better to open to the README.md in github repo */}}
   {{ if eq (printf "%s" .File) "_index" }}
     {{ $.Scratch.Set "filepath" (replace (printf "%s" .Path) "_index" "README") }}
   {{ end }}
-  {{ if ne $pageSection "docs" }}
+
+  {{/* Replace all site paths for the docs versions to just 'docs' */}}
+  {{ if in $pageSection "docs" }}
     {{ $.Scratch.Set "filepath" (replaceRE "v[0-9].[0-9]-docs" "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
   {{ end }}
-  {{ if eq $pageSection .Site.Params.master }}
-    {{ $.Scratch.Set "filepath" (replaceRE "development" "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
+  {{ if eq $pageSection $master }}
+   {{ $.Scratch.Set "filepath" (replaceRE (printf "%s" $master) "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
   {{ end }}
 
-  {{ $.Scratch.Set "gh_branch" ($.Param "github_branch") }}
-  {{ range .Site.Params.versions }}
-    {{ if eq $pageSection .dirpath }}
-      {{ $.Scratch.Set "gh_branch" .ghbranchname }}
+  {{/* Find the github branch for the corresponding docs version otherwise set to master */}}
+  {{ if in $pageSection "docs" }}
+    {{ range .Site.Params.versions }}
+      {{ if eq $pageSection .dirpath }}
+        {{ $.Scratch.Set "gh_branch" .ghbranchname }}
+      {{ end }}
     {{ end }}
+  {{ else }}
+    {{ $.Scratch.Set "gh_branch" "master" }}
   {{ end }}
-
-  {{ $gh_repo := ($.Param "github_repo") }}
 
   {{ if $gh_repo }}
+    {{ if ne $pageSection "blog" }}
     <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
     {{ $editURL := printf "%s/edit/%s/%s" $gh_repo ($.Scratch.Get "gh_branch") ($.Scratch.Get "filepath") }}
     {{ $issuesURL := printf "%s/issues/new?title=%s(%s)&labels=kind%2Fbug&template=bug-in-existing-docs.md" $gh_repo (htmlEscape $.Title) (htmlEscape $.Path)}}
@@ -30,4 +40,5 @@
     </div>
   {{ end }}
 
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
ensure all "edit in github" links for non docs sections of the website open to the master branch

also added back in the docs version drop down menu when viewing the "development" docs version (the last PR filtered it out)