### PR TITLE
link to Post to the knative.dev blog

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,48 @@
+{{ define "main" }}
+{{ if .Parent.IsHome }}
+{{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) }}
+{{ $.Scratch.Set "showwelcome" "true" }}
+{{ else }}
+{{ $.Scratch.Set "blog-pages" .Pages }}
+{{ $.Scratch.Set "showwelcome" "false" }}
+{{ end }}
+{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006")}}
+{{ $pageGroups := $pag.PageGroups}}
+{{ if eq $pag.PageNumber 1 }}
+{{ end }}
+{{ if ($.Scratch.Get "showwelcome") }}
+<div>
+  {{ partial "blogwelcome.html" . }}
+</div>
+{{ end }}
+<div class="row">
+  <div class="col-12">
+    {{ range $pageGroups }}
+    <h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
+    <ul class="list-unstyled mt-4">
+      {{ range .Pages }}
+      <li class="media mb-4">
+        <div class="media-body">
+          <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
+          <p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+          {{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
+          <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+          <p class="pt-0"><a href="{{ .RelPermalink }}">{{ T "ui_read_more"}}</a></p>
+        </div>
+      </li>
+      {{ end }}
+    </ul>
+    {{ end }}
+  </div>
+</div>
+<div class="row pl-2 pt-2">
+  <div class="col">
+    {{ template "_internal/pagination.html" . }}
+  </div>
+</div>
+{{ if ($.Scratch.Get "showwelcome") }}
+<div>
+  {{ partial "blogrelatedlinks.html" }}
+</div>
+{{ end }}
+{{ end }}

--- a/layouts/partials/blogrelatedlinks.html
+++ b/layouts/partials/blogrelatedlinks.html
@@ -1,0 +1,8 @@
+<hr>
+
+<b>Read what others are saying:</b>
+
+<ul>
+<li><a href="https://cloud.google.com/blog/search;query=knative;paginate=25;order=newest" target="_blank">Google Cloud Blog</a></li>
+<li><a href ="https://medium.com/tag/knative" target="_blank">Medium</a></li>
+</ul>

--- a/layouts/partials/blogwelcome.html
+++ b/layouts/partials/blogwelcome.html
@@ -1,0 +1,32 @@
+{{ if (in .Dir "releases") }}
+{{ $.Scratch.Set "blogsection" "Knative releases"}}
+{{ else if (in .Dir "articles") }}
+{{ $.Scratch.Set "blogsection" "Knative articles"}}
+{{ else if (in .Dir "events") }}
+{{ $.Scratch.Set "blogsection" "Knative social events"}}
+{{ else }}
+{{ $.Scratch.Set "blogsection" "Welcome to the Knative blog"}}
+{{ end }}
+
+<h1>{{ $.Scratch.Get "blogsection" }}</h1>
+{{ if eq .Dir "blog/" }}
+<p>Follow this blog to keep up-to-date with Knative.</p>
+<ul>
+<li><a href="./releases"><b>Release and feature announcements</b></a>: <br>{{ end }}
+{{ if or (in .Dir "releases") (eq .Dir "blog/") }}Learn about each Knative release, what's new and changed, and how to get started with the latest and greatest.{{ end }}
+
+{{ if eq .Dir "blog/" }}</li>
+<li><a href="./articles"><b>Articles</b></a>: <br>{{ end }}
+{{ if or (in .Dir "articles") (eq .Dir "blog/") }}Read about Knative-centric features, tools, and related topics.{{ end }}
+
+{{ if eq .Dir "blog/" }}</li>
+<li><a href="./events"><b>Future and past social events</b></a>: <br>{{ end }}
+{{ if or (in .Dir "events") (eq .Dir "blog/") }}Find out where the Knative team will be talking next, and where they've been.{{ end }}
+
+{{ if eq .Dir "blog/" }}</li>
+</ul>
+<hr>
+<p><b>Browse all Knative blog posts by date:</b></p>
+{{ else }}
+<hr>
+{{ end }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -31,14 +31,22 @@
   {{ end }}
 
   {{ if $gh_repo }}
+  <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
     {{ if ne $pageSection "blog" }}
-    <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
     {{ $editURL := printf "%s/edit/%s/%s" $gh_repo ($.Scratch.Get "gh_branch") ($.Scratch.Get "filepath") }}
     {{ $issuesURL := printf "%s/issues/new?title=%s(%s)&labels=kind%2Fbug&template=bug-in-existing-docs.md" $gh_repo (htmlEscape $.Title) (htmlEscape $.Path)}}
     <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
     <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-    </div>
-  {{ end }}
-
+    {{ else if (eq $pageSection "blog")}}
+    {{ if eq .Dir "blog/" }}
+    {{ $.Scratch.Set "blogsec" "Knative " }}
+    {{ else }}
+    {{ $getfolder := (replace (printf "%s" .Dir) "blog/" "" ) }}
+    {{ $getfolder := (replace (printf "%s" $getfolder) "/" " " ) }}
+    {{ $.Scratch.Set "blogsec" $getfolder }}
+    {{ end }}
+    <a href="https://github.com/knative/docs/new/master/{{ .Dir }}" target="_blank"><i class="fab fa-github fa-fw"></i>Post to the {{ $.Scratch.Get "blogsec" }}blog</a>
+    {{ end }}
+  </div>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Override the template to add a link that allows easy access to opening a PR and posting to any section of the blog

Added a footer to link to other related "blog" posts (based on search query or "knative" tag)

cc/ @mchmarny @rgregg 