### PR TITLE
Fix the "readfile" to include the file's TOC

### DIFF
--- a/layouts/shortcodes/readfile.md
+++ b/layouts/shortcodes/readfile.md
@@ -5,7 +5,7 @@
   {{ $.Scratch.Set "filepath" ( .Get "file" ) }}
 {{ end }}
 {{ if eq (.Get "markdown") "true" }}
-  {{ $.Scratch.Get "filepath" | readFile | markdownify }}
+  {{ readFile ($.Scratch.Get "filepath") }}
 {{ else }}
   {{ $.Scratch.Get "filepath" | readFile | safeHTML }}
 {{ end }}


### PR DESCRIPTION
enable rightside nav TOC for any file that is "included" using this readfile shortcode