### PR TITLE
ignore the local-build only 'resources' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 public/
 content/
+resources/


### PR DESCRIPTION
ignore this folder now that our builds no longer rely on the Hugo workaround of adding the "resources" folder in our repo (and pushing to the Netlify build)