### PR TITLE
Move all main menu configuration into site's default config

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -54,6 +54,28 @@ pygmentsStyle = "tango"
  # First one is picked as the Twitter card image if not set on page.
  #images = "/docs/images/...."
 
+[menu]
+
+  [[menu.main]]
+    name = "Documentation"
+    url = "/docs/"
+    weight = 10
+
+  [[menu.main]]
+    name = "Blog"
+    url = "/blog/"
+    weight = 30
+
+  [[menu.main]]
+    name = "Community"
+    url = "/community/"
+    weight = 40
+
+  [[menu.main]]
+    name = "Contributing"
+    url = "/contributing/"
+    weight = 60
+
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"


### PR DESCRIPTION
For local builds and easier maintenance:
- add all the main menu configuration into the site's default config.toml
- Dependent changes:
  - Remove "Docs" main menu from release-0.7: https://github.com/knative/docs/pull/1588
  - Remove other main menus from master: https://github.com/knative/docs/pull/1589