### PR TITLE
Make titles show - fix index.md and _index.md conflict

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -101,7 +101,7 @@ version = "v0.7"
 [[versions]]
   version = "development"
   ghbranchname = "master"
-  url = "https://knative.dev/development/"
+  url = "/development/"
   dirpath = "development"
 
 

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -95,8 +95,13 @@ mv temp/community/* content/en/contributing
 #    - .git* files
 #    - non-docs directories
 echo 'Converting all links in GitHub source files to Hugo supported relative links...'
-find . -type f -path '*/content/*.md' ! -name '*_index.md' ! -name '*README.md' ! -name '*serving-api.md' ! -name '*eventing-contrib-api.md' ! -name '*eventing-api.md' ! -name '*build-api.md' ! -name '*.git*' ! -path '*/.github/*' ! -path '*/hack/*' ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' -exec sed -i '/](/ { s#(\.\.\/#(../../#g; s#(\.\/#(../#g; /http/ !s#README\.md#index.html#g; /http/ !s#\.md##g }' {} +
-find . -type f -path '*/content/*/*/README.md' -exec sed -i '/](/ { /http/ !s#README\.md#index.html#g; /http/ !s#\.md##g }' {} +
+find . -type f -path '*/content/*.md' ! -name '*_index.md' ! -name '*README.md' \
+    ! -name '*serving-api.md' ! -name '*eventing-contrib-api.md' ! -name '*eventing-api.md' \
+    ! -name '*build-api.md' ! -name '*.git*' ! -path '*/.github/*' ! -path '*/hack/*' \
+    ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' \
+    -exec sed -i '/](/ { s#(\.\.\/#(../../#g; s#(\.\/#(../#g; /http/ !s#README\.md#index.html#g; /http/ !s#\.md##g }' {} +
+find . -type f -path '*/content/*/*/README.md' ! -name '_index.md' \
+    -exec sed -i '/](/ { /http/ !s#README\.md#index.html#g; /http/ !s#\.md##g }' {} +
 
 # Releases v0.6 and earlier doc releases:
 #use the "readfile" shortcodes to hide all the README.md files
@@ -105,11 +110,18 @@ echo 'Converting all README.md to index.md for "pre-release" and 0.7 or later do
 # v0.7 or later doc releases:
 # Rename "README.md" files to "index.md" and avoid unnecessary lower-level _index.md files
 # (to prevent nested shortcodes that can result in double markdown processing)
-# Skip the following README.md files (do not convert them to index.md):
-#  - content/en/README.md
+# Skip the following README.md files (do not convert them to index.md)
+# either because that README.md is for GitHub only, or to prevent conflicts
+# with the require _index.md file (Hugo's site section definition file):
+#  - all README.md files that with corresponding _index.md files
 #  - content/en/contributing/README.md
 #  - content/en/reference/README.md
-find . -type f -path '*/content/*/*/README.md' ! -path '*/contributing/*' ! -path '*/reference/*' ! -path '*/v0.6-docs/*' ! -path '*/v0.5-docs/*' ! -path '*/v0.4-docs/*' ! -path '*/v0.3-docs/*' ! -path '*/.github/*' ! -path '*/hack/*' ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' -exec bash -c 'mv "$1" "${1/\README/\index}"' -- {} \;
+find . -type f -path '*/content/*' -name 'README.md' \
+     ! -path '*/contributing/*' ! -path '*/v0.6-docs/*' ! -path '*/v0.5-docs/*' \
+     ! -path '*/v0.4-docs/*' ! -path '*/v0.3-docs/*' ! -path '*/.github/*' ! -path '*/hack/*' \
+     ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' \
+    -execdir bash -c 'if [ -e _index.md ]; then echo "skip $1"; else mv "$1" "${1/\README/\index}"; fi' -- {} \;
+
 
 # GET HANDCRAFTED SITE LANDING PAGE
 if "$LOCALBUILD"


### PR DESCRIPTION
During testing, missed that some titles on the production site were missing and discovered that Hugo does not like having both _index.md and index.md in the same directory.

This PR add logic to skip the file renaming from README.md to index.md for all folders where an `_index.md` exists. Note that _index.md files are required for all sections of content that have child nodes vs. a folder where only a single *.md files exists (which does not require an _index.md file and can work with frontmatter (alone like our code samples)).

Also fixes the /development/ section main docs page (which was missed) and formats a few of the really long lines