### PR TITLE
add a shortcode to dynamically or manually specify a version #

### DIFF
--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -1,0 +1,22 @@
+{{/* Use this to insert the docs version number. Get the directory path. */}}
+{{- $pageSection := .Page.Section -}}
+{{/* Set default version to latest release */}}
+{{- $.Scratch.Set "release-version" .Site.Params.version -}}
+{{/* Use the specified version override (not directory based) */}}
+{{- if (.Get "override") -}}
+  {{- $.Scratch.Set "release-version" (.Get "override") -}}
+{{- else -}}
+{{/* Use version based on the directory path (see .dirpath in config.toml) */}}
+  {{- range .Site.Params.versions -}}
+    {{- if eq $pageSection .dirpath -}}
+      {{- $.Scratch.Set "release-version" .version -}}
+    {{- end -}}
+  {{- end -}}
+  {{/* If a patch value is specified then append that, otherwise use '.0' */}}
+  {{- if (.Get "patch") -}}
+    {{- $.Scratch.Add "release-version" (.Get "patch") -}}
+  {{- else -}}
+    {{- $.Scratch.Add "release-version" ".0" -}}
+  {{- end -}}
+{{- end -}}
+{{- $.Scratch.Get "release-version" -}}


### PR DESCRIPTION
A new shortcode that we can use to "include" the version number. (note that adding multiple lines of comments in this file results in line breaks in the rendered output, thus no "usage notes" within the file itself).

Three options:
- `{{% version %}}`
  Dynamically insert the install version number based on the directory path (use .0 patch version)
  Example: `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`

- `{{% version patch=".20" %}}`
  Dynamically determine and insert version number and then manually append the specified a patch 
  release number.
  Example: `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`

- `{{% version override="v0.2.2" %}}`
  Manually insert and specify a version number. Same as just entering the value in the file but using
  this shortcode syntax lends itself to easier updates for each release (ie. search and replace).
  Example: `kubectl apply the-version=override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`

related https://github.com/knative/docs/pull/1643/files#diff-23910590edbe5d7c01c1397a3293a5faR35