### PR TITLE
fix ignore file config and force inpage toc option

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -20,10 +20,10 @@ relativeURLs = "true"
 # (the README.md files are kept for GitHub repo users so a landing pages appears)
 ignoreFiles = [
   "README.md$",
-  "docs/docs/reference/build.md",
-  "docs/docs/reference/serving.md",
-  "docs/docs/reference/eventing/eventing.md",
-  "docs/docs/reference/eventing/eventing-contrib-resources.md" ]
+  "/docs/reference/build.md",
+  "/docs/reference/serving.md",
+  "/docs/reference/eventing/eventing.md",
+  "/docs/reference/eventing/eventing-contrib-resources.md" ]
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]

--- a/layouts/partials/landingtoc.html
+++ b/layouts/partials/landingtoc.html
@@ -1,8 +1,11 @@
 {{/* In page TOC for landing pages (_index.md/.html) that exclude "readfile". */}}
-{{ if not (.HasShortcode "readfile") }}
+{{ if or (not (.HasShortcode "readfile")) ($.Page.Params.showlandingtoc) }}
 <div>
+  <b>Table of contents</b>
   <div>
+    <ul class="td-sidebar-nav" style="margin-bottom: 0;">
     {{ template "inpage-toc" (dict "page" . "section" .CurrentSection) }}
+    </ul>
   </div>
 </div>
 {{ end }}
@@ -10,21 +13,20 @@
 {{ $s := .section }}
 {{ $p := .page }}
 {{ $active := eq $p.CurrentSection $s }}
-{{ if not $active }}<ul class="td-sidebar-nav__section" style="margin-bottom: 0">
-  <li style="list-style: none">
-    <a  href="{{ $s.RelPermalink }}">{{ $s.LinkTitle }}</a>
+{{ if not $active }}
+  <li style="list-style: circle; padding-top:10px;">
+    <a href="{{ $s.RelPermalink }}">{{ $s.LinkTitle }}</a>
   </li>
-  <ul class="td-sidebar-link__sections">{{ end }}
-      {{ $pages := (union $s.Pages $s.Sections).ByWeight }}
-      {{ range $pages }}
-      {{ if .IsPage }}
-    <li style="list-style: none">
+  <ul>{{ end }}
+    {{ $pages := (union $s.Pages $s.Sections).ByWeight }}
+    {{ range $pages }}
+    {{ if .IsPage }}
+    <li style="list-style: circle; padding-top:10px;">
       <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
-      {{ else }}
+    {{ else }}
       {{ template "inpage-toc" (dict "page" $p "section" . ) }}
-      {{ end }}
+    {{ end }}
     </li>
-      {{ end }}
+    {{ end }}
   </ul>
-{{ if not $active }}</ul>{{ end }}
 {{ end }}


### PR DESCRIPTION
- fix the "ignored files" configuration
- added bullets to the "in-page" TOC
- enable the option to force the in-page TOC when the _index.md page also uses a `readfile` shortcode

Before: https://knative.dev/docs/reference/

After: 
![image](https://user-images.githubusercontent.com/11762685/62575343-6486e500-b84f-11e9-8419-b856d16039d4.png)

This is an in-flight change but is the real motivating factor for these updates (shows an intuitive in-page TOC after the overview description):
![image](https://user-images.githubusercontent.com/11762685/62575430-8da77580-b84f-11e9-9b4c-3ee239d41ea7.png)
