### PR TITLE
dynamic branch names for code samples

### DIFF
--- a/layouts/shortcodes/branch.md
+++ b/layouts/shortcodes/branch.md
@@ -1,0 +1,16 @@
+{{/* Use this to insert the docs branch name. Get the directory path. */}}
+{{- $pageSection := .Page.Section -}}
+{{/* Set default to branch to latest release */}}
+{{- $.Scratch.Set "release-branch" .Site.Params.latest_github_branch -}}
+{{/* Use the manually specified override */}}
+{{- if (.Get "override") -}}
+  {{- $.Scratch.Set "release-branch" (.Get "override") -}}
+{{- else -}}
+{{/* Use branch based on the directory path (see .dirpath in config/_default/params.toml) */}}
+  {{- range .Site.Params.versions -}}
+    {{- if eq $pageSection .dirpath -}}
+      {{- $.Scratch.Set "release-branch" .ghbranchname -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $.Scratch.Get "release-branch" -}}

--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -6,7 +6,7 @@
 {{- if (.Get "override") -}}
   {{- $.Scratch.Set "release-version" (.Get "override") -}}
 {{- else -}}
-{{/* Use version based on the directory path (see .dirpath in config.toml) */}}
+{{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
   {{- range .Site.Params.versions -}}
     {{- if eq $pageSection .dirpath -}}
       {{- $.Scratch.Set "release-version" .version -}}


### PR DESCRIPTION
similar to PR #71, this shortcode enable us to set a shortcode in all our code samples so that at build time, the correct branch name is defined within the corresponding `git clone -b "{{ branch }}" ....` commands of each file

plus corrected a typo in the "version" shortcode

Examples in the "in-progess" smoketest page: https://github.com/knative/docs/pull/1659