### PR TITLE
[WIP] v0.8 add /build/ redirects for removed files

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,9 @@
   HUGO_VERSION = "0.55.6"
   HUGO_ENV = "development"
 
+# Site redirects
+[[redirects]]
+  from = "/docs/build/*"
+  to = "/docs/build"
+  status = 301
+


### PR DESCRIPTION
site wide redirects for all /docs/build/* content to redirect to the remaining single build topic at /docs/build/index.html

HOLD until v0.8 content has been cut and published, otherwise this will start redirecting everything that is under /docs/build/ today