### PR TITLE
prevent netlify from  processing whitespace as codeblocks

### DIFF
--- a/layouts/shortcodes/readfile.md
+++ b/layouts/shortcodes/readfile.md
@@ -86,14 +86,14 @@ Parameters:
 {{/* If the first character is "/", the path is from the site's `baseURL`. */}}
 {{ if eq (.Get "file" | printf "%.1s") "/" }}
 
-  {{/* Use Hugo `readfile` behavior of path from site's `baseURL`. */}}
-  {{ $.Scratch.Set "filepath" ( .Get "file" ) }}
+{{/* Use Hugo `readfile` behavior of path from site's `baseURL`. */}}
+{{ $.Scratch.Set "filepath" ( .Get "file" ) }}
 
 {{ else }}
 
-  {{/* Make relative: Fetch the current directory and then append it to the specified `file=""` value */}}
-  {{ $.Scratch.Set "filepath" $.Page.Dir }}
-  {{ $.Scratch.Add "filepath" ( .Get "file" ) }}
+{{/* Make relative: Fetch the current directory and then append it to the specified `file=""` value */}}
+{{ $.Scratch.Set "filepath" $.Page.Dir }}
+{{ $.Scratch.Add "filepath" ( .Get "file" ) }}
 
 {{ end }}
 
@@ -101,21 +101,21 @@ Parameters:
 {{/* Check if the specified file exists */}}
 {{ if fileExists ($.Scratch.Get "filepath") }}
 
-  {{/* If Code, then highlight with the specified language. */}}
-  {{ if eq (.Get "code") "true" }}
+{{/* If Code, then highlight with the specified language. */}}
+{{ if eq (.Get "code") "true" }}
 
-      {{ highlight ($.Scratch.Get "filepath" | readFile | safeHTML ) (.Get "lang") "" }}
+{{ highlight ($.Scratch.Get "filepath" | readFile | safeHTML ) (.Get "lang") "" }}
 
-  {{ else }}
+{{ else }}
 
-    {{/* If HTML or Markdown. For Markdown`{{%...%}}`,  don't send content to processor again (use safeHTML). */}}
-    {{ $.Scratch.Get "filepath" | readFile | safeHTML }}
+{{/* If HTML or Markdown. For Markdown`{{%...%}}`,  don't send content to processor again (use safeHTML). */}}
+{{ $.Scratch.Get "filepath" | readFile | safeHTML }}
 
-  {{ end }}
+{{ end }}
 
 {{/* Say something if the file is not found and display the path that was specified in the shortcode (`file=" "`). */}}
 {{ else }}
 
-  <p style="color: #D74848"><b><i>Something's not right. The <code>{{ .Get "file" }}</code> file was not found.</i></b></p>
+<p style="color: #D74848"><b><i>Something's not right. The <code>{{ .Get "file" }}</code> file was not found.</i></b></p>
 
 {{ end }}


### PR DESCRIPTION
the production server treats the indentation as "markdown codeblock syntax" so removing all leading whitespace