### PR TITLE
ignore development content

### DIFF
--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -4,19 +4,21 @@
 {{- $.Scratch.Set "release-version" .Site.Params.version -}}
 {{/* Use the specified version override (not directory based) */}}
 {{- if (.Get "override") -}}
-  {{- $.Scratch.Set "release-version" (.Get "override") -}}
+{{- $.Scratch.Set "release-version" (.Get "override") -}}
 {{- else -}}
 {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
-  {{- range .Site.Params.versions -}}
-    {{- if eq $pageSection .dirpath -}}
-      {{- $.Scratch.Set "release-version" .version -}}
-    {{- end -}}
-  {{- end -}}
-  {{/* If a patch value is specified then append that, otherwise use '.0' */}}
-  {{- if (.Get "patch") -}}
-    {{- $.Scratch.Add "release-version" (.Get "patch") -}}
-  {{- else -}}
-    {{- $.Scratch.Add "release-version" ".0" -}}
-  {{- end -}}
+{{- range .Site.Params.versions -}}
+{{- if eq $pageSection .dirpath -}}
+{{- $.Scratch.Set "release-version" .version -}}
+{{- end -}}
+{{- end -}}
+{{/* If a patch value is specified then append that, otherwise use '.0' */}}
+{{- if (.Get "patch") -}}
+{{- $.Scratch.Add "release-version" (.Get "patch") -}}
+{{- else -}}
+{{- if ne $pageSection "development" -}}
+{{- $.Scratch.Add "release-version" ".0" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "release-version" -}}


### PR DESCRIPTION
forgot to fix this in the first version - prevents adding a .0 patch number to the docs release branch version for 'master'/the development section on knative.dev (so it shows /development/ as expected)

Example of error: 
`  kubectl apply --filename https://github.com/knative/serving/releases/download/development.0/serving.yaml`

