### PR TITLE
default pre-release to latest version

### DIFF
--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -6,19 +6,20 @@
 {{- if (.Get "override") -}}
 {{- $.Scratch.Set "release-version" (.Get "override") -}}
 {{- else -}}
+{{/* Keep using the latest version for the "pre-release" content */}}
+{{- if ne $pageSection "development" -}}
 {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
 {{- range .Site.Params.versions -}}
 {{- if eq $pageSection .dirpath -}}
 {{- $.Scratch.Set "release-version" .version -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
 {{/* If a patch value is specified then append that, otherwise use '.0' */}}
 {{- if (.Get "patch") -}}
 {{- $.Scratch.Add "release-version" (.Get "patch") -}}
 {{- else -}}
-{{- if ne $pageSection "development" -}}
 {{- $.Scratch.Add "release-version" ".0" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "release-version" -}}


### PR DESCRIPTION
instead of showing a non working URL, even though its not the correct path, better to point the URL to the latest working images