### PR TITLE
narrow grep search for PR fork name

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,6 +29,7 @@ source scripts/docs-version-settings.sh
 BUILDALLRELEASES="true"
 BRANCH="$DEFAULTBRANCH"
 FORK="$DEFAULTFORK"
+LOCALBUILD="false"
 
 # Manually specify your fork and branch for all builds.
 #
@@ -79,7 +80,7 @@ then
   echo 'Webhook Body:' "$INCOMING_HOOK_BODY"
 
   # Retrieve the repo URL and fork name
-  CLONEURL=$(echo "$INCOMING_HOOK_BODY" | grep -o -m 1 '\"clone_url\"\:\".*git\"' | sed -e 's/.*\"clone_url\"\:\"//;s/git\".*/git/' || true)
+  CLONEURL=$(echo "$INCOMING_HOOK_BODY" | grep -o -m 1 '\"clone_url\"\:\".*\.git\"\,\"svn_url\"' | head -1 | sed -e 's/.*\"clone_url\"\:\"//;s/\.git\".*/\.git/' || true)
   FORK=$(echo "$CLONEURL" | sed -e 's/https\:\/\/github.com\///;s/\/docs.git//')
 
   # If webhook is from a "PULL REQUEST" event


### PR DESCRIPTION
The regex for extracting the PR fork name is not behaving the same way on the Netlify server as it is during my tests on Mac and Linux. This tries to narrow the scope down the right instance of the "clone_url" value in the webhook payload.

I also add a variable to silence the "not found" warning for "localbuild".