### PR TITLE
Enable single branch auto PR builds

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,8 +1,8 @@
-# Knative DEFAULT Site Configuration
+# Knative "_default" Site Configuration
 
 # Usage notes:
-# To build with these settings, you run: "hugo"
-# Also see "production" and "staging" environment settings.
+# To build with these settings, see "scripts/build.sh" or "scripts/localbuild.sh"
+# Also see environment specific settings in "config/production" or "config/staging".
 
 title = "Knative"
 configDir = "config"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,6 +1,21 @@
 # Knative DEFAULT Site Params
-# Default site parameters, see "PRODUCTION" and "STAGING" for environment specific overrides
+# Default site parameters, see "PRODUCTION" "STAGING" and "LOCAL" for environment specific overrides
 
+# Default site parameters
+
+# Set default to "master" branch (see environment specific config for overrides)
+latest_github_branch = "master"
+# Default website version
+version = "development"
+
+# Section labels for versions
+doclabel = "Documentation "
+releaselabel = "Release: "
+masterlabel = "Pre-release"
+# Pre-release section path value ("master" docs directory folder on website)
+masterfolder = "development"
+
+# Footer content
 knativeAuthors = "The Knative Authors"
 commonsLicense = "Creative Commons Attribution 4.0"
 commons_license = "https://creativecommons.org/licenses/by/4.0/"
@@ -17,113 +32,12 @@ github_communityrepo = "https://github.com/knative/community"
 github_eventingrepo = "https://github.com/knative/eventing"
 github_servingrepo = "https://github.com/knative/serving"
 
-# Pre-release section path value ("master" docs directory folder on website)
-masterfolder = "development"
-
-# Default docs params
-# Latest Knative docs release/version - Default values (for Docsy Template)
-# Default GitHub branch
-latest_github_branch = "release-0.9"
-# Default website version
-version = "v0.9"
-
-# Doc versions params
-# Create a separate [[versions]] set for every version / doc set branch
-# Use the ghbranchname param for specifying the GitHub branchname ->
-# Example:
-#   [thisisalink](https://github.com/.../tree/{{< params "ghbranchname" >}}/...)
-#
-# [[versions]] - Defines a single "version" of the Knative docs
-#   version - Intuitive version label (ie. visible in menus)
-#   ghbranchname - Name of branch of the doc version in GitHub
-#                  (https://github.com/knative/docs/branches)
-#   url - Fully qualified website URL to the doc version
-#         (ie. https://www.knative.dev/[dirpath])
-#   dirpath - The content folder name of the doc version
-#           - Latest release is always set to "docs"
-#           - Past/archived releases change to "v#.#-docs",
-#             where # is the MAJOR and MINOR semantic version values
-
-# Latest version
-################
-# Set to "docs" path
-
-[[versions]]
-  version = "v0.9"
-  ghbranchname = "release-0.9"
-  url = "/docs/"
-  dirpath = "docs"
-
-# Archived versions
-###################
-# Prefix all past versions with release # "v#.#-docs"
-
-[[versions]]
-  version = "v0.8"
-  ghbranchname = "release-0.8"
-  url = "/v0.8-docs/"
-  dirpath = "v0.8-docs"
-
-[[versions]]
-  version = "v0.7"
-  ghbranchname = "release-0.7"
-  url = "/v0.7-docs/"
-  dirpath = "v0.7-docs"
-
-[[versions]]
-  version = "v0.6"
-  ghbranchname = "release-0.6"
-  url = "/v0.6-docs/"
-  dirpath = "v0.6-docs"
-
-[[versions]]
-  version = "v0.5"
-  ghbranchname = "release-0.5"
-  url = "/v0.5-docs/"
-  dirpath = "v0.5-docs"
-
-[[versions]]
-  version = "v0.4"
-  ghbranchname = "release-0.4"
-  url = "/v0.4-docs/"
-  dirpath = "v0.4-docs"
-
-[[versions]]
-  version = "v0.3"
-  ghbranchname = "release-0.3"
-  url = "/v0.3-docs/"
-  dirpath = "v0.3-docs"
-
-[[versions]]
-  version = "v0.2"
-  ghbranchname = "release-0.2"
-  url = "https://github.com/knative/docs/tree/release-0.2"
-  dirpath = "github-repo"
-
-[[versions]]
-  version = "v0.1"
-  ghbranchname = "release-0.1"
-  url = "https://github.com/knative/docs/tree/release-0.1"
-  dirpath = "github-repo"
-
-# Pre-release version
-###################
-# In-development (pre-release) content - "master" branch
-
-[[versions]]
-  version = "development"
-  ghbranchname = "master"
-  url = "/development/"
-  dirpath = "development"
-
-
 # User interface configuration
 [ui]
 # Set to true to display the nav bar in compact state (collapse menu).
 sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
-
 
 [links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
@@ -209,3 +123,4 @@ breadcrumb_disable = false
   external = "false"
   icon = "fa fa-link"
         desc = "Link to your Knative samples that live on another site"
+

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,5 +1,5 @@
 # Knative DEFAULT Site Params
-# Default site parameters, see "PRODUCTION" "STAGING" and "LOCAL" for environment specific overrides
+# Default site parameters, see "config/production" "config/staging" and "config/local" for environment specific overrides
 
 # Default site parameters
 

--- a/config/local/params.toml
+++ b/config/local/params.toml
@@ -1,5 +1,5 @@
-# Knative LOCALBUILD Site Params (adds to (or can override) Site "_default")
-# Use LOCALBUILD for local content testing
+# Knative "local" Site Params (adds to (or can override) Site "config/_default")
+# Use for local content testing
 
 # Usage notes:
 # To build with these settings, you use the "scripts/localbuild.sh" build script.

--- a/config/local/params.toml
+++ b/config/local/params.toml
@@ -1,0 +1,26 @@
+# Knative LOCALBUILD Site Params (adds to (or can override) Site "_default")
+# Use LOCALBUILD for local content testing
+
+# Usage notes:
+# To build with these settings, you use the "scripts/localbuild.sh" build script.
+# The build uses every setting defined in "config/_default" and then merges or
+# overrides all the settings defined here.
+
+# Default docs params for "local" environment
+
+# Local evnvironment version
+version = "Preview"
+# Section labels for versions
+doclabel = "Local Build: "
+releaselabel = "Local Build: "
+
+# Local build version
+################
+# Set to "docs" path
+
+[[versions]]
+  version = "Preview"
+  ghbranchname = "n/a"
+  url = "/docs/"
+  dirpath = "docs"
+

--- a/config/production/config.toml
+++ b/config/production/config.toml
@@ -1,4 +1,4 @@
-# Knative PRODUCTION Site Configuration (adds to or overrides "_default")
+# Knative "production" Site Configuration (adds to or overrides "_default")
 
 # Usage notes:
 # To build with these settings, you run: "hugo --config production"

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -15,3 +15,100 @@ enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/knative/docs/issues/new/?title=Page%20is%20helpful&labels=kind%2Fmeta">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues/new/?title=Page%20needs%20improvement&labels=kind%2Fmeta">tell us how we can improve</a>.'
+
+# Default docs params for "production" environment
+
+# Production GitHub branch
+latest_github_branch = "release-0.9"
+# Default website version
+version = "v0.9"
+
+# Doc versions params
+# Create a separate [[versions]] set for every version / doc set branch
+# Use the ghbranchname param for specifying the GitHub branchname ->
+# Example:
+#   [thisisalink](https://github.com/.../tree/{{< params "ghbranchname" >}}/...)
+#
+# [[versions]] - Defines a single "version" of the Knative docs
+#   version - Intuitive version label (ie. visible in menus)
+#   ghbranchname - Name of branch of the doc version in GitHub
+#                  (https://github.com/knative/docs/branches)
+#   url - Fully qualified website URL to the doc version
+#         (ie. https://www.knative.dev/[dirpath])
+#   dirpath - The content folder name of the doc version
+#           - Latest release is always set to "docs"
+#           - Past/archived releases change to "v#.#-docs",
+#             where # is the MAJOR and MINOR semantic version values
+
+# Latest version
+################
+# Set to "docs" path
+
+[[versions]]
+  version = "v0.9"
+  ghbranchname = "release-0.9"
+  url = "/docs/"
+  dirpath = "docs"
+
+# Archived versions
+###################
+# Prefix all past versions with release # "v#.#-docs"
+
+[[versions]]
+  version = "v0.8"
+  ghbranchname = "release-0.8"
+  url = "/v0.8-docs/"
+  dirpath = "v0.8-docs"
+
+[[versions]]
+  version = "v0.7"
+  ghbranchname = "release-0.7"
+  url = "/v0.7-docs/"
+  dirpath = "v0.7-docs"
+
+[[versions]]
+  version = "v0.6"
+  ghbranchname = "release-0.6"
+  url = "/v0.6-docs/"
+  dirpath = "v0.6-docs"
+
+[[versions]]
+  version = "v0.5"
+  ghbranchname = "release-0.5"
+  url = "/v0.5-docs/"
+  dirpath = "v0.5-docs"
+
+[[versions]]
+  version = "v0.4"
+  ghbranchname = "release-0.4"
+  url = "/v0.4-docs/"
+  dirpath = "v0.4-docs"
+
+[[versions]]
+  version = "v0.3"
+  ghbranchname = "release-0.3"
+  url = "/v0.3-docs/"
+  dirpath = "v0.3-docs"
+
+[[versions]]
+  version = "v0.2"
+  ghbranchname = "release-0.2"
+  url = "https://github.com/knative/docs/tree/release-0.2"
+  dirpath = "github-repo"
+
+[[versions]]
+  version = "v0.1"
+  ghbranchname = "release-0.1"
+  url = "https://github.com/knative/docs/tree/release-0.1"
+  dirpath = "github-repo"
+
+# Pre-release version
+###################
+# In-development (pre-release) content - "master" branch
+
+[[versions]]
+  version = "development"
+  ghbranchname = "master"
+  url = "/development/"
+  dirpath = "development"
+

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -1,6 +1,6 @@
-# Knative PRODUCTION Site Params (adds to (or can override) Site "_default")
+# Knative "production" Site Params (adds to (or can override) Site "config/_default")
 
-# Only add Google Custom Search and Feedback links to PRODUCTION
+# Only add Google Custom Search and Feedback links to "production"
 
 # Create ID at https://cse.google.com/cse/
 # Google Custom Search Engine ID. Remove or comment out to disable search.

--- a/config/staging/config.toml
+++ b/config/staging/config.toml
@@ -1,10 +1,8 @@
-# Knative STAGING Site Configuration (adds to or overrides "_default")
+# Knative "staging" Site Configuration (adds to or overrides "config/_default")
 
 # Usage notes:
-# To build with these settings, you run: "hugo --environment staging"
+# To build with these settings, see "scripts/build.sh"
 # Hugo build then uses every setting defined in "config/_default" and then merge
 # all settings defined here for "staging" on top of all those define for "_default".
 
 baseURL = ""
-title = "Knative STAGING"
-

--- a/config/staging/params.toml
+++ b/config/staging/params.toml
@@ -1,9 +1,25 @@
 # Knative STAGING Site Params (adds to (or can override) Site "_default")
-# Use STAGING for development, like inflight PR reviews and content testing
+# Use STAGING for development, like inflight PR reviews and content testing.
 
 # Usage notes:
-# To build with these settings, you run: "hugo --environment staging"
-# Hugo build then uses every setting defined in "config/_default" and then merge
-# all settings defined here for "staging" on top of all those define for "_default".
+# To build with these settings, you use must specify the Hugo environment to 
+# "staging" (hugo -e staging). Or configure the environment in Netlify.
+# The build uses every setting defined in "config/_default" and then merges or
+# overrides all the settings defined here.
 
+# Default docs params for "staging" environment
+
+# Staging environment version
+version =  "Preview"
+# Section labels for versions
+doclabel = "Pull Request: "
+releaselabel = "Pull Request: "
+
+# Set PRs to build to the "docs" path
+
+[[versions]]
+  version = "Preview"
+  ghbranchname = "PR"
+  url = "/docs/"
+  dirpath = "docs"
 

--- a/config/staging/params.toml
+++ b/config/staging/params.toml
@@ -1,5 +1,5 @@
-# Knative STAGING Site Params (adds to (or can override) Site "_default")
-# Use STAGING for development, like inflight PR reviews and content testing.
+# Knative "staging" Site Params (adds to (or can override) Site "config/_default")
+# Use for development, like inflight PR reviews and content testing.
 
 # Usage notes:
 # To build with these settings, you use must specify the Hugo environment to 

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,7 +1,7 @@
 {{/* Prefix labels for menus */}}
-{{ $.Scratch.Set "docLabel" "Documentation " }}
-{{ $.Scratch.Set "releaseLabel" "Release: " }}
-{{ $masterMainLabel := "Pre-release" }}
+{{ $.Scratch.Set "docLabel" .Site.Params.doclabel }}
+{{ $.Scratch.Set "releaseLabel" .Site.Params.releaselabel }}
+{{ $masterMainLabel := .Site.Params.masterlabel }}
 {{ $masterDropLabel := .Site.Params.masterfolder }}
 
 {{/* set defaults for version and dropdown menu highlighting */}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,11 +7,11 @@
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.55.6"
-  HUGO_ENV = "development"
+  HUGO_ENV = "staging"
 
 [context.branch-deploy.environment]
   HUGO_VERSION = "0.55.6"
-  HUGO_ENV = "development"
+  HUGO_ENV = "staging"
 
 # Site redirects
 [[redirects]]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,7 +88,7 @@ then
   # If webhook is from a "PULL REQUEST" event
   if echo "$INCOMING_HOOK_BODY" | grep -q -m 1 '\"pull_request\"'
   then
-  # Build only the content in the PR using the "Staging" environment settings (config/staging)
+  # Build only the content in the PR using the "staging" environment settings (config/staging)
     PRBUILD="true"
     BUILDSINGLEBRANCH="true"
     BUILDALLRELEASES="false"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,7 @@ BRANCH="$DEFAULTBRANCH"
 FORK="$DEFAULTFORK"
 
 # Set build default values
+BUILDENVIRONMENT="production"
 BUILDALLRELEASES="true"
 BUILDSINGLEBRANCH="false"
 LOCALBUILD="false"
@@ -107,13 +108,17 @@ then
     else
       # If PR was not merged, extract the branch name (to use for preview build)
       BRANCH=$(echo "$FORK_BRANCH" | sed -e 's/.*\://')
+      # Use "Staging" environment settings (config/staging)
+      BUILDENVIRONMENT="staging"
     fi
   else
     # Webhook from "PUSH event"
-    # If the event was from someone's fork, then get their branchname (otherwise use default: "latest knative release branch")
+    # If the event was from someone's fork, then get their branchname
     if [ "$FORK" != "knative" ]
     then
       BRANCH=$(echo "$INCOMING_HOOK_BODY" | grep -o -m 1 ':"refs\/heads\/.*\"\,\"before\"' | sed -e 's/.*:\"refs\/heads\///;s/\"\,\"before\".*//' || true)
+      # Use "Staging" environment settings (config/staging)
+      BUILDENVIRONMENT="staging"
     fi
   fi
 else
@@ -122,6 +127,7 @@ fi
 
 echo '------ BUILD DETAILS ------'
 echo 'Build type:' "$CONTEXT"
+echo 'Build environment:' "$BUILDENVIRONMENT"
 if [ "$PRBUILD" = "true" ]
 then
 # Builds only the content from the PR
@@ -158,7 +164,7 @@ source scripts/processsourcefiles.sh
 
 # BUILD MARKDOWN
 # Start HUGO build
-cd themes/docsy && git submodule update -f --init && cd ../.. && hugo
+cd themes/docsy && git submodule update -f --init && cd ../.. && hugo --environment "$BUILDENVIRONMENT" 
 
 echo '------ BUILD SUCCESSFUL ------'
 echo 'VIEW STAGED CONTENT:' "$DEPLOY_URL"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@
 # for continuous builds and PR previews.
 # (https://www.netlify.com/docs/webhooks/)
 
-# Requirement: You fork must include all releases and maintain the same
+# Requirement: Your fork must include all releases and maintain the same
 # branch names and structure as the knative/docs repo. Otherwise, set up
 # your build using the flag: BUILDALLRELEASES="FALSE"
 
@@ -23,13 +23,17 @@
 # Quit on error
 set -e
 
-# Get and set default values
+# Retrieve the default docs version
 source scripts/docs-version-settings.sh
-
-BUILDALLRELEASES="true"
+# Use default repo and branch from docs-version-settings.sh
 BRANCH="$DEFAULTBRANCH"
 FORK="$DEFAULTFORK"
+
+# Set build default values
+BUILDALLRELEASES="true"
+BUILDSINGLEBRANCH="false"
 LOCALBUILD="false"
+PRBUILD="false"
 
 # Manually specify your fork and branch for all builds.
 #
@@ -49,12 +53,12 @@ while getopts f:b:a: arg; do
   echo '------ BUILDING DOCS FROM: ------'
   case $arg in
     f)
-      echo "${OPTARG}" 'FORK'
+      echo 'FORK:' "${OPTARG}"
       # Set specified knative/docs repo fork
       FORK="${OPTARG}"
       ;;
     b)
-      echo "${OPTARG}" 'BRANCH'
+      echo 'BRANCH:' "${OPTARG}"
       # Set specified branch
       BRANCH="${OPTARG}"
       ;;
@@ -62,17 +66,18 @@ while getopts f:b:a: arg; do
       echo 'BUILDING ALL RELEASES'
       # True by default. If set to "false" , the build does not clone nor build
       # the docs releases from other branches.
-      # REQUIRED: To build all docs version when $FORK is specified, all
-      # knative/docs branches must also exist in the target $FORK, and
-      # the names of each branch must match the branches of the knative/docs
-      # repo ('release-0.X'). For example: 'release-0.7', 'release-0.6', etc...
+      # REQUIRED: If you specify a fork ($FORK), all of the same branches 
+      # (with the same branch names) that are built in knative.dev must
+      # also exist and be available in that $FORK (ie, 'release-0.X'). 
+      # See /config/production/params.toml for the list of the branches
+      # their names that are currently built in knative.dev.
       BUILDALLRELEASES="${OPTARG}"
       ;;
   esac
 done
 
 # If a webhook triggered the build, get repo fork and branch name
-if [[ $INCOMING_HOOK_BODY || $INCOMING_HOOK_TITLE || $INCOMING_HOOK_URL ]]
+if [ "$INCOMING_HOOK_BODY" ] || [ "$INCOMING_HOOK_TITLE" ] || [ "$INCOMING_HOOK_URL" ]
 then
   echo '------ BUILD REQUEST FROM KNATIVE/DOCS WEBHOOK ------'
   echo 'Webhook Title:' "$INCOMING_HOOK_TITLE"
@@ -82,6 +87,10 @@ then
   # If webhook is from a "PULL REQUEST" event
   if echo "$INCOMING_HOOK_BODY" | grep -q -m 1 '\"pull_request\"'
   then
+  # Build only the content in the PR using the "Staging" environment settings (config/staging)
+    PRBUILD="true"
+    BUILDSINGLEBRANCH="true"
+    BUILDALLRELEASES="false"
     # Get PR number
     PULL_REQUEST=$(echo "$INCOMING_HOOK_BODY" | grep -o -m 1 '\"number\"\:.*\,\"pull_request\"' | sed -e 's/\"number\"\://;s/\,\"pull_request\"//' || true)
     # Retrieve the fork and branch from PR webhook
@@ -90,8 +99,9 @@ then
     FORK=$(echo "$FORK_BRANCH" | sed -e 's/\:.*//')
     # If PR was merged, just run default build and deploy production site (www.knative.dev)
     MERGEDPR=$(echo "$INCOMING_HOOK_BODY" | grep -o '\"merged\"\:true\,' || : )
-    if [ "$MERGEDPR" ]
+    if [ "$MERGEDPR" = "true" ] 
     then
+      # For merged PR, do not get branch name (use default: "latest knative release branch")
       echo '------ PR' "$PULL_REQUEST" 'MERGED ------'
       echo 'Running production build - publishing new changes'
     else
@@ -100,7 +110,7 @@ then
     fi
   else
     # Webhook from "PUSH event"
-    # If the event was from someone's fork, then get their branchname
+    # If the event was from someone's fork, then get their branchname (otherwise use default: "latest knative release branch")
     if [ "$FORK" != "knative" ]
     then
       BRANCH=$(echo "$INCOMING_HOOK_BODY" | grep -o -m 1 ':"refs\/heads\/.*\"\,\"before\"' | sed -e 's/.*:\"refs\/heads\///;s/\"\,\"before\".*//' || true)
@@ -112,30 +122,35 @@ fi
 
 echo '------ BUILD DETAILS ------'
 echo 'Build type:' "$CONTEXT"
+if [ "$PRBUILD" = "true" ]
+then
+# Builds only the content from the PR
+echo 'Building docs from PR#' "$PULL_REQUEST" 
+else
+# The Netlify $PULL_REQUEST variable doesnt like the use of our multiple repos: Always returns false if we dont override it(see above)
+echo 'Pull Request:' "$PULL_REQUEST"
+fi
+# Only display these values when building other user's forks
 if [ "$FORK" != "knative" ]
 then
-echo 'Building content from:' "$FORK"
+echo 'Building From Fork:' "$FORK"
 echo 'Using Branch:' "$BRANCH"
 fi
 echo 'Commit HEAD:' "$HEAD"
 echo 'Commit SHA:' "$COMMIT_REF"
 # Other Netlify flags that aren't currently useful
 #echo 'Repo:' "$REPOSITORY_URL"
-# Doesnt seem to like multiple repos and always returns false when not overriden (see above)
-echo 'Pull Request:' "$PULL_REQUEST"
 #echo 'GitHub ID:' "$REVIEW_ID"
 
 echo '------ WHEN BUILD SUCCESSFULLY COMPLETES ------'
 # Only show published site if build triggered by PR merge
-if [ "$MERGEDPR" ]
+if [ "$MERGEDPR" = "true" ]
 then
-echo '------ CONTENT PUBLISHED ------'
-echo 'View published content at:' "$URL"
+echo 'Published content can be viewed at:' "$URL"
 else
-echo '------ PREVIEW CHANGES ------'
 # Gets overritten and shows only latest build
 #echo 'Shared staging URL:' "$DEPLOY_PRIME_URL"
-echo 'View staged content (unique to only this build):' "$DEPLOY_URL"
+echo 'Staged content (unique to only this build) can be viewed at:' "$DEPLOY_URL"
 fi
 
 # Process the source files

--- a/scripts/localbuild.sh
+++ b/scripts/localbuild.sh
@@ -121,7 +121,5 @@ mkdir -p content
 source scripts/processsourcefiles.sh
 
 # BUILD MARKDOWN
-# TEST
-echo "$BUILDENVIRONMENT"
 # Start HUGO build
 hugo server --baseURL "" --environment "$BUILDENVIRONMENT"

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -66,9 +66,9 @@ then
   echo '------ BUILDING CONENT FROM REMOTE ------'
   echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"
   git clone --quiet -b "$BRANCH" https://github.com/"$FORK"/docs.git content/en
+else
 # DEFAULT: LOCAL BUILD
 # Assumes that knative/docs and knative/website are cloned to the same directory.
-else
   echo '------ BUILDING ONLY FROM YOUR LOCAL KNATIVE/DOCS CLONE ------'
   pwd
   cp -r ../docs content/en/
@@ -127,8 +127,8 @@ echo 'Converting all README.md to index.md for "pre-release" and 0.7 or later do
 # (and to prevent deeply nested shortcodes ==> double markdown processing issues)
 #
 # Some README.md files should not be converted to index.md, either because that README.md 
-# a file that is used only in the GitHub repo, or to prevent conflicts Hugo build 
-# conflicts (index.md and _index.md files in the same directory is not supported).
+# is a file that's used only in the GitHub repo, or to prevent Hugo build conflicts
+# (index.md and _index.md files in the same directory is not supported).
 #
 # Do not convert the following README.md files to index.md:
 #  - files in doc releases v0.6 and earlier

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -3,40 +3,38 @@
 #######################################################################################
 
 echo '------ PROCESSING SOURCE FILES ------'
-# Pull in content from the separate community source and docs source repos
-# (make it look like they live in the content folder of knative/website )
-# Use a temp directory and move files around to prevent git clone error (fails if directory exists)
-# Note: This forces a complete build of all versions of all files in the site
-
-if "$LOCALBUILD"
-then
-echo '------ RUNNING A LOCAL BUILD ------'
-fi
+# Default to a local build. Otherwise, retreives content from the specified source repos. 
+# All builds copy or clone the content into the "content" folder of knative/webiste before starting the Hugo build.
+# A temp directory is used and move files around and prevent git clone errors (fails if directory exists).
 
 # Clean slate: Make sure that nothing from a past build exists in the /content/ or /temp/ folders
 rm -rf content/en
 rm -rf temp
-echo 'Cloning Knative documentation from their source repositories.'
 
-if "$BUILDALLRELEASES"
+if [ "$BUILDALLRELEASES" = "true" ]
 then
-  echo '------ BUILDING ALL DOC RELEASES FROM' "$FORK" '------'
+# PRODUCTION BUILD (ALL RELEASES)
+# Full build for knative.dev (config/production). Contributors can also use this for personal builds.
+  echo '------ BUILDING ALL DOC RELEASES ------'
   # Build Knative docs from:
   # - https://github.com/"$FORK"/docs
   # - https://github.com/knative/community
-  echo '------ Cloning Pre-release docs (master) ------'
+
+  # Build all branches (assumes $FORK contains all docs versions)
+  echo '------ Cloning Community and Pre-release docs (master) ------'
   # MASTER
   echo 'Getting blog posts and community owned samples from knative/docs master branch'
-  git clone -b master https://github.com/"$FORK"/docs.git content/en
+  git clone --quiet -b master https://github.com/"$FORK"/docs.git content/en
   echo 'Getting pre-release development docs from master branch'
   # Move "pre-release" docs content into the 'development' folder:
   mv content/en/docs content/en/development
   # DOCS BRANCHES
   echo '------ Cloning all docs releases ------'
   # Get versions of released docs from their branches in "$FORK"/docs
-  echo 'Getting the latest release from the' "$BRANCH" 'branch of' "$FORK"
+  echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"
   # Latest version is defined in website/scripts/docs-version-settings.sh
-  git clone -b "$BRANCH" https://github.com/"$FORK"/docs.git temp/release/latest
+  # If this is a PR build, then build that content as the latest release (assume PR preview builds are always from "latest")
+  git clone --quiet -b "$BRANCH" https://github.com/"$FORK"/docs.git temp/release/latest
 
   ###############################################################
   # Template for next release:
@@ -46,20 +44,30 @@ then
 
   # Only copy and keep the "docs" folder from all branched releases:
   mv temp/release/latest/docs content/en/docs
-  echo 'Getting the archived docs releases'
-  git clone -b "release-0.8" https://github.com/"$FORK"/docs.git temp/release/v0.8
+
+  echo 'Getting the archived docs releases from branches in:' "$FORK"'/docs'
+  git clone --quiet -b "release-0.8" https://github.com/"$FORK"/docs.git temp/release/v0.8
   mv temp/release/v0.8/docs content/en/v0.8-docs
-  git clone -b "release-0.7" https://github.com/"$FORK"/docs.git temp/release/v0.7
+  git clone --quiet -b "release-0.7" https://github.com/"$FORK"/docs.git temp/release/v0.7
   mv temp/release/v0.7/docs content/en/v0.7-docs
-  git clone -b "release-0.6" https://github.com/"$FORK"/docs.git temp/release/v0.6
+  git clone --quiet -b "release-0.6" https://github.com/"$FORK"/docs.git temp/release/v0.6
   mv temp/release/v0.6/docs content/en/v0.6-docs
-  git clone -b "release-0.5" https://github.com/"$FORK"/docs.git temp/release/v0.5
+  git clone --quiet -b "release-0.5" https://github.com/"$FORK"/docs.git temp/release/v0.5
   mv temp/release/v0.5/docs content/en/v0.5-docs
-  git clone -b "release-0.4" https://github.com/"$FORK"/docs.git temp/release/v0.4
+  git clone --quiet -b "release-0.4" https://github.com/"$FORK"/docs.git temp/release/v0.4
   mv temp/release/v0.4/docs content/en/v0.4-docs
-  git clone -b "release-0.3" https://github.com/"$FORK"/docs.git temp/release/v0.3
+  git clone --quiet -b "release-0.3" https://github.com/"$FORK"/docs.git temp/release/v0.3
   mv temp/release/v0.3/docs content/en/v0.3-docs
   echo 'Moving cloned files into their v#.#-docs website folders'
+elif [ "$BUILDSINGLEBRANCH" = "true" ]
+then
+# SINGLE REMOTE BRANCH BUILD
+# Build only the content from $FORK and $BRANCH
+  echo '------ BUILDING CONENT FROM REMOTE ------'
+  echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"
+  git clone --quiet -b "$BRANCH" https://github.com/"$FORK"/docs.git content/en
+# DEFAULT: LOCAL BUILD
+# Assumes that knative/docs and knative/website are cloned to the same directory.
 else
   echo '------ BUILDING ONLY FROM YOUR LOCAL KNATIVE/DOCS CLONE ------'
   pwd
@@ -69,15 +77,15 @@ fi
 echo '------ Cloning contributor docs ------'
 # COMMUNITY
 echo 'Getting Knative contributor guidelines from the master branch of knative/community'
-git clone -b master https://github.com/knative/community.git temp/community
+git clone --quiet -b master https://github.com/knative/community.git temp/community
 # Move files into existing "contributing" folder
 mv temp/community/* content/en/contributing
 
 # CLEANUP
-  # Delete temporary directory
-  # (clear out unused files, including archived-copies/past-versions of blog posts and contributor samples)
-  echo 'Cleaning up temp directory'
-  rm -rf temp
+# Delete temporary directory
+# (clear out unused files, including archived-copies/past-versions of blog posts and contributor samples)
+echo 'Cleaning up temp directory'
+rm -rf temp
 
 # MAKE RELATIVE LINKS WORK
 # We want users to be able view and use the source files in GitHub as well as on the site.
@@ -108,17 +116,23 @@ find . -type f -path '*/content/*.md' ! -name '*_index.md' ! -name '*README.md' 
 find . -type f -path '*/content/*/*/README.md' ! -name '_index.md' \
     -exec sed -i '/](/ { /http/ !s#README\.md#index.html#g; /http/ !s#\.md##g }' {} +
 
-# Releases v0.6 and earlier doc releases:
-#use the "readfile" shortcodes to hide all the README.md files
-# (by nesting them within the _index.md files)
+# HIDE README FROM URLS
+# For SEO, dont use "README" in the URL 
+# (convert them to index.md or nest them within _index.md section file using "readfile")
+# v0.6 and earlier doc releases:
+# Use the "readfile" shortcodes to nest README.md files within the _index.md files.
 echo 'Converting all README.md to index.md for "pre-release" and 0.7 or later doc releases'
 # v0.7 or later doc releases:
-# Rename "README.md" files to "index.md" and avoid unnecessary lower-level _index.md files
-# (to prevent nested shortcodes that can result in double markdown processing)
-# Skip the following README.md files (do not convert them to index.md)
-# either because that README.md is for GitHub only, or to prevent conflicts
-# with the require _index.md file (Hugo's site section definition file):
-#  - all README.md files that with corresponding _index.md files
+# Rename "README.md" files to "index.md" to avoid unnecessary lower-level _index.md files
+# (and to prevent deeply nested shortcodes ==> double markdown processing issues)
+#
+# Some README.md files should not be converted to index.md, either because that README.md 
+# a file that is used only in the GitHub repo, or to prevent conflicts Hugo build 
+# conflicts (index.md and _index.md files in the same directory is not supported).
+#
+# Do not convert the following README.md files to index.md:
+#  - files in doc releases v0.6 and earlier
+#  - README.md files in folders that also include _index.md files
 #  - content/en/contributing/README.md
 #  - content/en/reference/README.md
 find . -type f -path '*/content/*/*/*' -name 'README.md' \


### PR DESCRIPTION
Auto PR builds already work if that fork includes all the branches that are currently used to build knative.dev. 

These changes now generate a preview for any PR using only a single branch by default (ie. only the contents in the fork and branch of the PR). For local builds, only the locally cloned knative/website and knative/docs are used to build a preview by default. 

There are now three Hugo build environments:
- productions (config/production/params.toml) - by default, builds all versions/branches (same as whats on knative.dev)
- staging (config/staging/params.toml) - by default, builds only the fork and branch from the PR
- local (config/local/params.toml) - by default, builds from the local knative/docs clone

*Note: all environments can use the override flags in the scripts/`*`build.sh files*

Resulting changes:

Running local build with $ scripts/localbuild.sh:
![image](https://user-images.githubusercontent.com/11762685/65002399-75903080-d8a8-11e9-9374-4917cee1bc3a.png)

For Pull Requests and related Push events:
![image](https://user-images.githubusercontent.com/11762685/65002392-6d37f580-d8a8-11e9-8d1e-d9b65197d437.png)

The auto PR build preview links and results are exposed on the Deploy logs page: https://app.netlify.com/sites/knative/deploys