### PR TITLE
Resolve poor cookie popup behavior

### DIFF
--- a/assets/scss/_cookies.scss
+++ b/assets/scss/_cookies.scss
@@ -1,12 +1,13 @@
 // Override bootstrap modal for cookie consent
 
 .modal.custom .modal-dialog {
-  margin: 0;  
   position: fixed;
-  right: 35px;
+  margin: 0;
   top: 35px;
-  left: 35px;
-  max-width: $modal-xl;
+  max-width: fit-content;
+  left: 5%;
+  padding-left: 15%;
+  padding-right: 15%;
   .modal-body {
     padding-bottom: 0;
     background: rgba(195,195,195,1.0); 

--- a/static/js/cookie-consent.js
+++ b/static/js/cookie-consent.js
@@ -2,7 +2,8 @@
 $.getScript("/js/js.cookie.js");
 
 // Get cookie consent if the UTC time zone is within the EU+ and user has not consented previously (no cookie exists)
-$(document).ready(function(){
+// Wait for page to fully load before checking
+$(window).on('load', function(){
   // If the cookie expired or does not exist
   if ( typeof(Cookies) == 'undefined' || Cookies.get('site-cookie') == null ){
     // if within EU time zone show consent dialog


### PR DESCRIPTION
Prevent cookie consent popup from showing after the user has consented (clicked accept).

- change when the javascript is run and wait for full page load (not document ready)
- also noticed that on really large viewport the modal dialog appeared left justified so changed the CSS so that it floats more towards the center

Tested by:
1. setting local computer clock to London
2. accepting cookie
3. clicking on all install pages and then through several blog posts and community pages

Staged: https://5d8e51aad5281f000c4060f2--knative.netlify.com/docs/