### PR TITLE
fix 'hreflang' error

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -31,7 +31,6 @@ ignoreFiles = [
 theme = ["docsy"]
 
 # Language settings
-contentDir = "content/en"
 defaultContentLanguage = "en"
 # TODO: Investigate if this should be true when other nls exist?
 defaultContentLanguageInSubdir = false

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -3,16 +3,15 @@
 # Note: NL source is maintained in the translations branch of the knative/docs repo:
 # <TODO Create branch for nls> https://github.com/knative/docs/tree/translations) </TODO>
 
-[languages]
-
 [en]
-title = "Knative"
-description = "Knative provides a set of components for building modern, source-centric, and container-based applications that can run anywhere."
-languageName ="English"
-# Weight used for sorting.
-weight = 1
-time_format_default = "02.01.2006"
-time_format_blog = "02.01.2006"
+  title = "Knative"
+  description = "Knative provides a set of components for building modern, source-centric, and container-based applications that can run anywhere."
+  languageName = "English"
+  contentDir = "content/en"
+  # Weight used for sorting.
+  weight = 1
+  time_format_default = "02.01.2006"
+  time_format_blog = "02.01.2006"
 
 # Template/example for additional NLs
 # (where translated source is "content/[LANG]" and config file is "il8n/[LANG].toml")
@@ -20,10 +19,10 @@ time_format_blog = "02.01.2006"
 # Example: LANG = ja (Japanese):
 #
 # [ja]
-# title = "Knative"
-# description = "Knative [ja translation here]"
-# languageName ="Japanese"
-# contentDir = "content/ja"
-# weight = 2
-# time_format_default = "2006.02.01"
-# time_format_blog = "2006.02.01"
+#   title = "Knative"
+#   description = "Knative [ja translation here]"
+#   languageName = "Japanese"
+#   contentDir = "content/ja"
+#   weight = 2
+#   time_format_default = "2006.02.01"
+#   time_format_blog = "2006.02.01"


### PR DESCRIPTION
Received a "Incorrect hreflang implementation on https://knative.dev/" error warning from "Google Search Engine" related to SEO. Basically we currently fail to properly specify a language because the `languages.toml` file is configured wrong (old syntax was incorrectly carried over).

The following changes should set our lang to 'en-us' and add the missing 'hreflang' to our header.