### PR TITLE
update redirects now that docs/build is gone

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,41 +15,7 @@
 
 # Site redirects
 [[redirects]]
-  from = "/docs/build/auth"
-  to = "/docs/build"
+  from = "/docs/build/*"
+  to = "/docs/"
   status = 301
-  
-[[redirects]]
-  from = "/docs/build/build-templates"
-  to = "/docs/build"
-  status = 301
-   
-[[redirects]]
-  from = "/docs/build/builder-contract"
-  to = "/docs/build"
-  status = 301
-   
-[[redirects]]
-  from = "/docs/build/builds"
-  to = "/docs/build"
-  status = 301
-   
-[[redirects]]
-  from = "/docs/build/installing-build-component"
-  to = "/docs/build"
-  status = 301
-   
-[[redirects]]
-  from = "/docs/build/personas"
-  to = "/docs/build"
-  status = 301
-  
-[[redirects]]
-  from = "/docs/build/samples"
-  to = "/docs/build"
-  status = 301
-  
-  [[redirects]]
-  from = "/docs/reference/build-api"
-  to = "/docs/build"
-  status = 301
+


### PR DESCRIPTION
simplifying the redirect for the deprecated build content (see dependent https://github.com/knative/docs/pull/1942)