### PR TITLE
allow permanent links - redirect archived URL to latest

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,3 +19,9 @@
   to = "/docs/"
   status = 301
 
+# Enable permanent links to a release (link persists after release is archived)
+# This should be updated each release to the latest version number
+[[redirects]]
+  from = "/v0.10-docs/*"
+  to = "/docs/:splat"
+  status = 200


### PR DESCRIPTION
allow someone to create a permanent link to the latest version which is published to `/docs/`, so that link persists even after that content is archived (for example `/v#.#-docs/`)

fixes #25 

with this change, you can link to what the future "archived URL" will be, which will be redirected to the "latest version"

for each release, this file must be updated to the latest docs release version number

Example: 
todays latest version is `release-0.10` and the latest version is always published under the directory `/docs/*`

if you want to link specifically to only a topic in the v0.10 content, you can modify the URL to indicate the release version (future archive location) `/v0.10-docs/`, and that URL will redirect to `/docs/` until it gets archived to its permanent folder/archive location (`/v0.10-docs/`)

therefore `https://knative.dev/v0.10-docs/*` (or any path) gets redirected to `https://knative.dev/docs/*`(ie. `https://knative.dev/v0.10-docs/install/` -> `https://knative.dev/docs/install/`)

Live example from staging:

https://deploy-preview-101--knative.netlify.com/v0.10-docs/serving/accessing-logs/

(try other URLs by appending to `https://deploy-preview-101--knative.netlify.com/v0.10-docs/`)