### PR TITLE
Fix the source of some other broken links

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -3,10 +3,10 @@
 
 # Default site parameters
 
-# Set default to "master" branch (see environment specific config for overrides)
-latest_github_branch = "master"
-# Default website version
-version = "development"
+# GitHub branch (latest release)
+latest_github_branch = "release-0.10"
+# Default version (latest release)
+version = "v0.10"
 
 # Section labels for versions
 doclabel = "Documentation "

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -16,13 +16,6 @@ enable = true
 yes = 'Glad to hear it! Please <a href="https://github.com/knative/docs/issues/new/?title=Page%20is%20helpful&labels=kind%2Fmeta">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues/new/?title=Page%20needs%20improvement&labels=kind%2Fmeta">tell us how we can improve</a>.'
 
-# Default docs params for "production" environment
-
-# Production GitHub branch
-latest_github_branch = "release-0.10"
-# Default website version
-version = "v0.10"
-
 # Doc versions params
 # Create a separate [[versions]] set for every version / doc set branch
 # Use the ghbranchname param for specifying the GitHub branchname ->

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,4 +1,5 @@
-
+{{/* Show only on production site (not local builds since we can't determine version) */}}
+{{ if not .Site.IsServer }}
 {{ $master := .Site.Params.masterfolder }}
 {{ if .Path }}
   {{/* Set default values */}}
@@ -56,7 +57,7 @@
     <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 
     {{/* Determine the Knative component */}}
-    {{ if or (eq $pageSection "docs") (eq $pageSection "development") }}
+    {{ if or (eq $pageSection "docs") (eq $pageSection .Site.Params.masterfolder) }}
       {{ if in (printf "%s" ($.Scratch.Get "filepath")) "/serving/" }}
         {{ $.Scratch.Set "gh_repo" (printf "%s/issues/new" ($.Param "github_servingrepo")) }}
       {{ end }}
@@ -82,4 +83,5 @@
     {{ end }}
   </div>
   {{ end }}
+{{ end }}
 {{ end }}

--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -1,25 +1,26 @@
 {{/* Use this to insert the docs version number. Get the directory path. */}}
 {{- $pageSection := .Page.Section -}}
-{{/* Set default version to latest release */}}
+{{/* Get latest release and the name of the pre-release section */}}
 {{- $.Scratch.Set "release-version" .Site.Params.version -}}
+{{- $preRelease := .Site.Params.masterfolder -}}
 {{/* Use the specified version override (not directory based) */}}
 {{- if (.Get "override") -}}
-{{- $.Scratch.Set "release-version" (.Get "override") -}}
+  {{- $.Scratch.Set "release-version" (.Get "override") -}}
 {{- else -}}
-{{/* Keep using the latest version for the "pre-release" content */}}
-{{- if ne $pageSection "development" -}}
-{{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
-{{- range .Site.Params.versions -}}
-{{- if eq $pageSection .dirpath -}}
-{{- $.Scratch.Set "release-version" .version -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{/* If a patch value is specified then append that, otherwise use '.0' */}}
-{{- if (.Get "patch") -}}
-{{- $.Scratch.Add "release-version" (.Get "patch") -}}
-{{- else -}}
-{{- $.Scratch.Add "release-version" ".0" -}}
-{{- end -}}
+  {{/* Keep using the latest version for the "pre-release" content (masterfolder) */}}
+  {{- if ne $pageSection $preRelease -}}
+    {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
+    {{- range .Site.Params.versions -}}
+      {{- if eq $pageSection .dirpath -}}
+        {{- $.Scratch.Set "release-version" .version -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{/* If a patch value is specified then append that, otherwise use '.0' */}}
+  {{- if (.Get "patch") -}}
+    {{- $.Scratch.Add "release-version" (.Get "patch") -}}
+  {{- else -}}
+    {{- $.Scratch.Add "release-version" ".0" -}}
+  {{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "release-version" -}}


### PR DESCRIPTION
Looks like "Hugo config file overrides" dont work as they say they should and a parameter set in `_default`, doesnt always get overridden by those same parameters in `production`.

the knative.dev/development dynamic version variables render using "development" as the version (rather than the defined "latest version).

- test against a config parameter (replace hard coded values)
- move site wide default values into `_default`
- re-add indentation to the code

Related: 
- https://github.com/knative/docs/pull/1975
- https://github.com/knative/docs/pull/1974

/cc @adrcunha @eallred-google 