### PR TITLE
Reduce drop down menu and archive our really old archives

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -9,10 +9,12 @@ latest_github_branch = "master"
 version = "development"
 
 # Section labels for versions
+# Current release
 doclabel = "Documentation "
 releaselabel = "Release: "
+# Pre-release
 masterlabel = "Pre-release"
-# Pre-release section path value ("master" docs directory folder on website)
+# section path value ("master" docs directory folder on website)
 masterfolder = "development"
 
 # Footer content

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -73,47 +73,17 @@ version = "v0.10"
   dirpath = "v0.7-docs"
 
 [[versions]]
-  version = "v0.6"
-  ghbranchname = "release-0.6"
-  url = "/v0.6-docs/"
-  dirpath = "v0.6-docs"
-
-[[versions]]
-  version = "v0.5"
-  ghbranchname = "release-0.5"
-  url = "/v0.5-docs/"
-  dirpath = "v0.5-docs"
-
-[[versions]]
-  version = "v0.4"
-  ghbranchname = "release-0.4"
-  url = "/v0.4-docs/"
-  dirpath = "v0.4-docs"
-
-[[versions]]
-  version = "v0.3"
-  ghbranchname = "release-0.3"
-  url = "/v0.3-docs/"
-  dirpath = "v0.3-docs"
-
-[[versions]]
-  version = "v0.2"
-  ghbranchname = "release-0.2"
-  url = "https://github.com/knative/docs/tree/release-0.2"
-  dirpath = "github-repo"
-
-[[versions]]
-  version = "v0.1"
-  ghbranchname = "release-0.1"
-  url = "https://github.com/knative/docs/tree/release-0.1"
-  dirpath = "github-repo"
+  version = "Archives"
+  ghbranchname = ""
+  url = "https://github.com/knative/docs/branches"
+  dirpath = ""
 
 # Pre-release version
 ###################
 # In-development (pre-release) content - "master" branch
 
 [[versions]]
-  version = "development"
+  version = "Pre-release"
   ghbranchname = "master"
   url = "/development/"
   dirpath = "development"

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -36,11 +36,11 @@
   <span class="d-none d-lg-inline d-xl-inline active">{{ printf "%s" ($.Scratch.Get "docLabel") }}</span>
   <span class="d-sm-inline d-md-inline d-lg-none d-xl-none">{{ printf "%s" ($.Scratch.Get "releaseLabel") }}</span>
 </a>
-{{/* generate dropdown menu */}}
+{{/* generate dropdown menu - make the Pre-release menu item gray */}}
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
   {{ range .Site.Params.versions }}
   <a
   class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active{{ end }}"
-  style="{{ if eq .version $masterDropLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
+  style="{{ if eq .version $masterMainLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
   {{ end }}
 </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,8 +14,31 @@
   HUGO_ENV = "staging"
 
 # Site redirects
+
+# Redirect all deprecated Knative Build component pages
 [[redirects]]
   from = "/docs/build/*"
+  to = "/docs/"
+  status = 301
+
+# Redirect archived versions to the latest
+[[redirects]]
+  from = "/v0.6-docs/*"
+  to = "/docs/"
+  status = 301
+
+[[redirects]]
+  from = "/v0.5-docs/*"
+  to = "/docs/"
+  status = 301
+
+[[redirects]]
+  from = "/v0.4-docs/*"
+  to = "/docs/"
+  status = 301
+
+[[redirects]]
+  from = "/v0.3-docs/*"
   to = "/docs/"
   status = 301
 


### PR DESCRIPTION
Reduce the doc version drop down menu to just the last 4 releases. Replace all older versions with a single link to "Archives" which simply opens to the knative/docs branches page.

[See staged site](https://5dccb94f98b47a0009603a09--knative-v1.netlify.com/docs/)

![image](https://user-images.githubusercontent.com/11762685/68821271-bdca9580-0642-11ea-87c2-b2d375d9b05a.png)

Test redirects (...`/v0.5-docs/`...): [https://5dccb94f98b47a0009603a09--knative-v1.netlify.com/v0.5-docs/]()

This also includes a fix for the drop-down menu label for "pre-release" content (`master` branch)

Fixes #31 

cc/ @bbrowning 