### PR TITLE
Fix some nested content rendering issues

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,15 +2,15 @@
   publish = "public"
 
 [context.production.environment]
-  HUGO_VERSION = "0.55.6"
+  HUGO_VERSION = "0.56.0"
   HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.55.6"
+  HUGO_VERSION = "0.56.0"
   HUGO_ENV = "staging"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.55.6"
+  HUGO_VERSION = "0.56.0"
   HUGO_ENV = "staging"
 
 # Site redirects


### PR DESCRIPTION
I noticed that local builds on Hugo v0.56.0 lacked bad HTML like the site so pushing the Hugo version update to knative.dev.

I also found that `markup: "mmark"` along with Hugo 0.56.0 fixed the rendering further. See PR https://github.com/knative/docs/pull/2003 for an example ive pushed to the site (for testing).

Here are results from my fork (zero rendering issues): https://5de5dbbfce75b84563279d6c--knative-v1.netlify.com/docs/install/knative-custom-install/#installing-knative

One negative to using "mmark" is the loss of the right-side page navigation (the in-page TOC disappears)

Related: https://github.com/knative/docs/issues/1202

Fixes #108 