### PR TITLE
upgrade to hugo 0.61.0 and use Goldmark processor

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -42,17 +42,15 @@ enableGitInfo = true
 
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
-# Highlighting config
-pygmentsCodeFences = true
-pygmentsUseClasses = false
-# Use the new Chroma Go highlighter in Hugo.
-pygmentsUseClassic = false
-#pygmentsOptions = "linenos=table"
-# See https://help.farbox.com/pygments.html
-pygmentsStyle = "tango"
+# Configure how URLs look like per section.
+[permalinks]
+blog = "/:section/:year/:month/:day/:slug/"
 
- # First one is picked as the Twitter card image if not set on page.
- #images = "/docs/images/...."
+# Image processing configuration.
+[imaging]
+resampleFilter = "CatmullRom"
+quality = 75
+anchor = "smart"
 
 [menu]
 
@@ -75,22 +73,3 @@ pygmentsStyle = "tango"
     name = "Contributing"
     url = "/contributing/"
     weight = 60
-
-# Configure how URLs look like per section.
-[permalinks]
-blog = "/:section/:year/:month/:day/:slug/"
-
-## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = true
-angledQuotes = false
-latexDashes = true
-# Needs investigation - opens all links in new tab (canonifyURLs conflict?)
-#hrefTargetBlank = true
-
-# Image processing configuration.
-[imaging]
-resampleFilter = "CatmullRom"
-quality = 75
-anchor = "smart"

--- a/config/_default/markup.toml
+++ b/config/_default/markup.toml
@@ -1,0 +1,37 @@
+defaultMarkdownHandler = "goldmark"
+
+# Configuration for Goldmark markdown processor
+# https://gohugo.io/getting-started/configuration-markup/#configure-markup
+[goldmark]
+  [goldmark.extensions]
+    definitionList = true
+    footnote = true
+    linkify = true
+    strikethrough = true
+    table = true
+    taskList = true
+    typographer = true
+  [goldmark.parser]
+    attribute = true
+    autoHeadingID = true
+  [goldmark.renderer]
+    hardWraps = false
+    unsafe = false
+    xHTML = false
+
+# Configuration for the Chroma syntax highlighting
+# https://gohugo.io/getting-started/configuration-markup/#highlight
+[highlight]
+  codeFences = true
+  hl_Lines = ""
+  lineNoStart = 1
+  lineNos = false
+  lineNumbersInTable = true
+  noClasses = true
+  style = "tango"
+  tabWidth = 4
+
+# Specify which level of headings to show in the right-side TOC
+[tableOfContents]
+  endLevel = 2
+  startLevel = 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,15 +2,15 @@
   publish = "public"
 
 [context.production.environment]
-  HUGO_VERSION = "0.56.0"
+  HUGO_VERSION = "0.61.0"
   HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.56.0"
+  HUGO_VERSION = "0.61.0"
   HUGO_ENV = "staging"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.56.0"
+  HUGO_VERSION = "0.61.0"
   HUGO_ENV = "staging"
 
 # Site redirects
@@ -27,6 +27,7 @@
 
 # Update to include the recently archived version
 # Redirects all previously published versions to the latest
+
 [[redirects]]
   from = "/v0.7-docs/*"
   to = "/docs/"


### PR DESCRIPTION
- upgrade to Hugo v 0.61.0
  - update corresponding syntax highlighting
     - add highlight config and switch to Goldmark settings
     - move all markdown configuration into separate configuration file
     - removed unused or invalid blackfriday and pygment settings
- fixes nested list problems: 
   - https://github.com/knative/docs/issues/1202
   - https://github.com/knative/docs/issues/2026
- markdown now gets rendered the same way as GitHub

Fully tested using [scripts/localbuild.sh](https://github.com/knative/website/blob/master/scripts/localbuild.sh)

Note: External links no longer open in new tabs/windows by default

fixes #109 