### PR TITLE
Improve cookie consent to include a "hide" for opting out

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -21,7 +21,7 @@ masterfolder = "development"
 
 # Footer content
 knativeAuthors = "The Knative Authors"
-commonsLicense = "Creative Commons Attribution 4.0"
+commonsLicense = "CC By 4.0"
 commons_license = "https://creativecommons.org/licenses/by/4.0/"
 apacheLicense = "Apache 2.0"
 apache_license = "https://www.apache.org/licenses/LICENSE-2.0"
@@ -29,6 +29,8 @@ knativeLicense = "Knative Licensing"
 knative_license = "https://github.com/knative/docs/blob/master/LICENSE"
 privacyPolicy = "Privacy Policy"
 privacy_policy = "https://policies.google.com/privacy"
+cookieUsage = "Cookie Usage"
+cookie_usage = "/about-analytics-cookies/"
 
 # GitHub repositories
 github_docsrepo = "https://github.com/knative/docs"

--- a/content-override/en/about-analytics-cookies.md
+++ b/content-override/en/about-analytics-cookies.md
@@ -10,7 +10,7 @@ on the website.
 
 Continue to sections below for details about knative.dev, or use the following resources to learn about cookies in general:
 
-- Learn about basic site analytics usuage at [https://www.cookiechoices.org/](https://www.cookiechoices.org/).
+- Learn about basic site analytics usuage at: [https://www.cookiechoices.org/](https://www.cookiechoices.org/)
 
 - You can also watch a video about [how Google uses cookies](http://www.google.com/intl/en/policies/technologies/cookies/).
 
@@ -46,7 +46,7 @@ IP address. For more information about the data collected, [view our Privacy Pol
 
 If you prefer to view the Knative docs from within the [knative/docs
 ](https://github.com/knative/docs/tree/master/docs) GitHub repository,
-view details about the cookies and tracking at
+view details about their cookies and tracking at
 [GitHub Privacy Statement](https://help.github.com/en/github/site-policy/github-privacy-statement#what-information-github-collects).
 
 ## Options for opting out

--- a/content-override/en/about-analytics-cookies.md
+++ b/content-override/en/about-analytics-cookies.md
@@ -1,0 +1,72 @@
+---
+title: "Learn about Google Analytics cookies"
+linkTitle: "Learn about cookies"
+type: "docs"
+---
+
+By using this website, you are confirming that you accept our use of cookies for
+the purposes of collecting anonymous usage data to improve the user experience and content
+on the website.
+
+Continue to sections below for details about knative.dev, or use the following resources to learn about cookies in general:
+
+- Learn about basic site analytics usuage at [https://www.cookiechoices.org/](https://www.cookiechoices.org/).
+
+- You can also watch a video about [how Google uses cookies](http://www.google.com/intl/en/policies/technologies/cookies/).
+
+## What are cookies?
+
+[Cookies](https://en.wikipedia.org/wiki/HTTP_cookie) are small pieces of data that is sent from a
+website and stored on the user's computer by the user's web browser while that user is browsing.
+Cookies were designed to be a reliable mechanism for websites to remember stateful information
+or to record the user's browsing activity.
+
+For example, a cookie can be used to determine if a user has already visited a page and whether or
+not that user has already been presented with a certain notice or announcement. As a rule, cookies
+will make your browsing experience better, like ensuring that those same notices or announcements
+don't pop-up over every page.
+
+Many sites use cookies and analytics. You might have agreed to their usage when you created an
+account, used their service, or viewed their webpage (cookie consent notice).
+
+However, you can choose to disable cookies on knative.dev, or any other website. The most
+effective way to do this is to disable cookies in your browser but you can loose some website
+behavior.
+
+## What cookies are used on knative.dev
+
+We use [Google Analytics](https://marketingplatform.google.com/about/analytics/) tracking on
+knative.dev. These cookies are used to store information, such as what pages you visited and for
+how long, whether you have been to the site before, and what site referred you to the web page.
+We also learn about what types of content and topic areas you
+are interested in, including what content or sections never get viewed or used.
+
+These cookies contain no personally identifiable information (PII) but they will use your computer’s
+IP address. For more information about the data collected, [view our Privacy Policy](https://policies.google.com/privacy).
+
+If you prefer to view the Knative docs from within the [knative/docs
+](https://github.com/knative/docs/tree/master/docs) GitHub repository,
+view details about the cookies and tracking at
+[GitHub Privacy Statement](https://help.github.com/en/github/site-policy/github-privacy-statement#what-information-github-collects).
+
+## Options for opting out
+
+Use the following options to prevent your data from being shared with websites.
+
+### Opt-out Browser Add-on
+
+You can use the Google Analytics Opt-out Browser Add-on to prevent your usage data from being
+sent to Google Analytics. [Learn more, including how to install the add-on](http://tools.google.com/dlpage/gaoptout).
+
+### Disabling cookies
+
+You can manually restrict the use of cookies in your web browser. General details about how to
+control cookie usage in your web browser are available at:
+
+[Apple Safari](https://support.apple.com/guide/safari/manage-cookies-and-website-data-sfri11471/mac)
+
+[Google Chrome](https://support.google.com/chrome/bin/answer.py?hl=en-GB&answer=95647&p=cpn_cookies)
+
+[Microsoft Internet Explorer](https://support.microsoft.com/en-us/help/17442/windows-internet-explorer-delete-manage-cookies)
+
+[Mozilla Firefox](https://support.mozilla.org/en-US/kb/block-websites-storing-cookies-site-data-firefox?redirectlocale=en-US&redirectslug=Blocking+cookies)

--- a/layouts/partials/cookie-consent-modal.html
+++ b/layouts/partials/cookie-consent-modal.html
@@ -2,17 +2,15 @@
 <div id="cookieModal" class="modal custom fade" role="dialog" data-backdrop="false">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
-      <!-- <div class="modal-header">
-       <p class="modal-title">Website analytics cookies</p>
-       </div> -->
       <div class="modal-body">
-        <p>We use cookies. <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google Analytics</a> is used to improve your experience and help us understand site traffic and page usage. <a href="https://www.cookiechoices.org/" target="_blank">Learn more.</a></p>
+        <p>We use cookies. <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google Analytics</a> is used to improve your experience and help us understand site traffic and page usage.</p>
         <div class="consent-buttons">
-          <button type="button" class="btn btn-sm mr-3 mb-4" onclick="optout()">Opt Out</button>
+          <button type="button" class="btn btn-sm mr-3 mb-4" onclick="learnaboutcookies()">Learn more</button>
           <button type="button" class="btn btn-sm btn-secondary mr-3 mb-4" onclick="acceptcookie()">Accept</button>
           <div class="opt-out">
-            <!--<p>You have the option to refuse the use of cookies by selecting the appropriate settings on your browser, however please note that if you do this, you may not be able to use the full functionality of this website.</p> -->
-            <p>Opt out of Google Analytics by disabling cookies or JavaScript in your browser, or by using the <b><a href="https://tools.google.com/dlpage/gaoptout" target="_blank">opt-out service provided by Google</a></b>.</p>
+            <hr>
+            <p><a href="/about-analytics-cookies/">Learn about analytics cookies and how you can take steps to opt-out from sharing your usage data.</a></p>
+            <button type="button" class="btn btn-sm btn-primary mr-3 mb-4" onclick="optout()">I understand how to opt-out, disable this notice.</button>
           </div>
         </div>
       </div>

--- a/layouts/partials/cookie-consent-modal.html
+++ b/layouts/partials/cookie-consent-modal.html
@@ -10,7 +10,7 @@
           <div class="opt-out">
             <hr>
             <p><a href="/about-analytics-cookies/">Learn about analytics cookies and how you can take steps to opt-out from sharing your usage data.</a></p>
-            <button type="button" class="btn btn-sm btn-primary mr-3 mb-4" onclick="optout()">I understand how to opt-out, disable this notice.</button>
+            <button type="button" class="btn btn-sm btn-primary mr-3 mb-4" onclick="optout()">I understand how to opt-out, hide this notice.</button>
           </div>
         </div>
       </div>

--- a/layouts/partials/cookie-notice.html
+++ b/layouts/partials/cookie-notice.html
@@ -2,7 +2,7 @@
 <div class="cookienotice">
   <div class="text">
     <p>We use analytics and cookies to understand site traffic. Information about your use of
-      our site is shared with Google for that purpose. <a href="https://www.cookiechoices.org/" target="_blank">Learn more.</a>
+      our site is shared with Google for that purpose. <a href="/about-analytics-cookies/">Learn more.</a>
     </p>
   </div>  
   <div class="buttons">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -22,11 +22,11 @@
         <h6 class="text-white">Knative developers</h6>
       </div>
       <!-- Override for Knative licensing START -->
-      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
+      <div class="col-12 col-sm-4 text-center py-0 order-sm-2">
         {{ if .Site.Params.commonsLicense }}<small class="text-white">
           {{ if .Site.Params.knative_license }}
-          <p>&copy; {{ now.Year }} {{ .Site.Params.knativeAuthors }} |  <b><a class="text-white" href="{{ .Site.Params.knative_license }}">{{ .Site.Params.knativeLicense }}</a></b> | <b><a class="text-white" href="{{ .Site.Params.privacy_policy }}">{{ .Site.Params.privacyPolicy }}</a></b><br>
-          <a class="text-white d-none d-lg-none d-xl-inline" href="{{ .Site.Params.commons_license }}">{{ .Site.Params.commonsLicense }}</a><span class="text-white d-none d-md-none d-lg-none d-xl-inline">, </span><a class="text-white d-none  d-md-none d-lg-none d-xl-inline" href="{{ .Site.Params.apache_license }}">{{ .Site.Params.apacheLicense }}</a></p>
+          <p>&copy; {{ now.Year }} {{ .Site.Params.knativeAuthors }} | <b><a class="text-white" href="{{ .Site.Params.privacy_policy }}">{{ .Site.Params.privacyPolicy }}</a></b> | <b><a class="text-white" href="/about-analytics-cookies/">Cookie Usage</a></b> | <b><a class="text-white" href="{{ .Site.Params.knative_license }}">{{ .Site.Params.knativeLicense }}</a></b><br>
+          <span class="d-none d-lg-inline d-xl-inline" style="white-space:nowrap"><a class="text-white" href="{{ .Site.Params.commons_license }}">{{ .Site.Params.commonsLicense }}</a>, <a class="text-white" href="{{ .Site.Params.apache_license }}">{{ .Site.Params.apacheLicense }}</a></span></p>
           {{ end }}
         </small>
         {{ end }}

--- a/static/js/cookie-consent.js
+++ b/static/js/cookie-consent.js
@@ -4,7 +4,7 @@ $(window).on('load', function(){
   // Use local copy of JavaScript Cookie v2.2.1
   $.getScript('/js/js.cookie.js', function() {
     // If the cookie expired or does not exist
-    if ( typeof(Cookies) == 'undefined' || Cookies.get('site-cookie') == null ){
+    if ( typeof(Cookies) == 'undefined' || Cookies.get('site_cookie') == null ){
       // if within EU time zone show consent dialog
       if (testEUtimezone()){
         toggleconsent();
@@ -17,10 +17,10 @@ $(window).on('load', function(){
     }
   });
 });
-// Use UTC to determine if the time zone resides in or around the EU (within UTC -1 to +6)
+// Use UTC to determine if the time zone resides in or around the EU (within UTC 0 to +4 - https://www.timeanddate.com/time/zones/eu)
 function testEUtimezone(){
   var offset = new Date().getTimezoneOffset();
-  if ((offset >= -360) && (offset <= 60)){ // European time zones
+  if ((offset >= -240) && (offset <= 0)){ // European time zone in minutes
     console.log("UTC time zone within the EU");
     return true;
   }
@@ -31,19 +31,27 @@ function testEUtimezone(){
 function acceptcookie(){
   $("#cookieModal").modal('hide');
   $(".cookienotice").hide();
-  // set the cookie for 12 mns
-  Cookies.set('site-cookie', 'accepted', { expires: 365 });
+  // set cookie that expires in 12 mns
+  Cookies.set('site_cookie', 'accepted', { expires: 365 });
   console.log("I consent to the use of cookies on knative.dev");
 }
-// Show info about how to opt-out
+// Hide cookie notice and confirm user knows how to opt-out
 function optout(){
+  $("#cookieModal").modal('hide');
+  $(".cookienotice").hide();
+  // set cookie that expires in 12 mns
+  Cookies.set('site_cookie', 'opt_out', { expires: 365 });
+  console.log("I read knative.dev/about-analytics-cookies and understand how to opt-out of Google Analytics cookies");
+}
+// Show info about how to opt-out
+function learnaboutcookies(){
   $(".opt-out").toggle();
 }
 // Close cookie notice (cookie use accepted only for session)
 function closenotice(){
   // Consent to cookies for only this session
-  Cookies.set('site-cookie', 'accepted');
-  $(".cookienotice").toggle();
+  Cookies.set('site_cookie', 'accepted');
+  togglenotice();
   console.log("I consent to the use of cookies on knative.dev for this session");
 }
 
@@ -51,17 +59,17 @@ function closenotice(){
 
 // Manually remove existing cookie
 function removecookie(){
-  Cookies.remove('site-cookie');
+  Cookies.remove('site_cookie');
 }
-// Manually show cookie consent modal
+// Toggle cookie consent modal
 function toggleconsent(){
   $("#cookieModal").modal('toggle');
 }
-// Manually show cookie notice
+// Toggle cookie notice
 function togglenotice(){
   $(".cookienotice").toggle();
 }
-// Manually check if the 'site-cookie' exists
+// Manually check if the 'site_cookie' exists
 function getcookie(){
-  return Cookies.get('site-cookie');
+  return Cookies.get('site_cookie');
 }


### PR DESCRIPTION
- Add detailed page about cookies [knative.dev/about-analytics-cookies/]() 
  - move cookiechoices.org links to that page.
- Redirect  both "learn more" links to new page (consent dialog and non-EU notice).
- Narrow "EU time zone" down to just four zones
- Ensure cookies use underscore (not hyphen) - per developers.google.com/analytics/devguides
- Add cookie usage page to footer

**View test server**
View the new page at [Preview staged changes](https://deploy-preview-120--knative.netlify.com/about-analytics-cookies/). To view the revised dialog, from your browser console you can run `togglenotice()` or `toggleconsent()` to show the notice and consent (or you can change the time settings on your computer to an EU time zone).

**Screencaps of changed layout and buttons/links**

Default consent dialog:
![image](https://user-images.githubusercontent.com/11762685/72415090-c7789280-3784-11ea-9eb7-605d36c5e1d4.png)

Click "learn more":
![image](https://user-images.githubusercontent.com/11762685/72415144-e70fbb00-3784-11ea-936e-e32e46b9ea7c.png)

Footer:
![image](https://user-images.githubusercontent.com/11762685/72484147-2c99ab80-37b8-11ea-94d5-ceb8bbb02145.png)
