### PR TITLE
Add the tab[s] shortcodes.

### DIFF
--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -6,7 +6,7 @@
 	{{ with .Inner }}
 	{{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
 	{{ else }}
-	asdf
+	{{- errorf "[%s] %q: tab title does not exist" site.Language.Lang .Page.Path -}}
 	{{ end }}
 {{ else }}
 	{{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,0 +1,13 @@
+{{ if .Parent }}
+	{{ $name := trim (.Get "name") " " }}
+	{{ if not (.Parent.Scratch.Get "tabs") }}
+	{{ .Parent.Scratch.Set "tabs" slice }}
+	{{ end }}
+	{{ with .Inner }}
+	{{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
+	{{ else }}
+	asdf
+	{{ end }}
+{{ else }}
+	{{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
+{{ end}}

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -1,0 +1,31 @@
+{{ $tab_set_id := .Get "name" | default (printf "tabset-%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize }}
+{{ $default := .Get "default" }}
+{{ if .Inner }}{{/* We don't use the inner content, but Hugo will complain if we don't reference it. */}}{{ end }}
+{{ $tabs := .Scratch.Get "tabs" }}
+<ul class="nav nav-tabs" id="{{ $tab_set_id }}" role="tablist">
+  {{ range $i, $e := $tabs }}
+    {{ $id := printf "%s-%d" $tab_set_id $i }}
+    {{ $active := "" }}
+    {{ if eq $default $e.name }}
+      {{ $active = "active" }}
+    {{ end }}
+    <li class="nav-item {{ $active }}">
+      <a class="nav-link {{ $active }}" id="{{ $id }}-tab" data-toggle="tab" href="#{{ $id }}" role="tab" aria-controls="{{ $id }}" aria-selected="true">{{ trim .name " " }}</a>
+    </li>
+  {{ end }}
+</ul>
+
+<div class="tab-content">
+{{ range $i, $e := $tabs }}
+  {{ $id := printf "%s-%d" $tab_set_id $i }}
+  {{ $active := "" }}
+  {{ if eq $default $e.name }}
+    {{ $active = "active" }}
+  {{ end }}
+  <div class="tab-pane {{ $active }}" id="{{ $id }}" role="tabpanel" aria-labelledby="{{ $id }}-tab">
+    {{ with .content }}
+      {{ . }}
+    {{ end }}
+  </div>
+{{ end }}
+</div>


### PR DESCRIPTION
I found out about these here and they're exactly what I've been missing in my life: https://kubernetes.io/docs/contribute/style/hugo-shortcodes/#tabs

/assign @samodell @evankanderson @RichieEscarez 
/hold

I don't yet know how to validate or try this, so I'm sort of hoping a YOLO CI job might show something 🤞 