### PR TITLE
This adds an artifact shortcode.

### DIFF
--- a/layouts/shortcodes/artifact.html
+++ b/layouts/shortcodes/artifact.html
@@ -1,0 +1,27 @@
+{{- $org := trim (.Get "org") " " -}}
+{{- if not $org -}}
+{{- $org = "knative" -}}
+{{- end -}}
+{{- $repo := trim (.Get "repo") " " -}}
+{{- $file := trim (.Get "file") " " -}}
+{{- $pageSection := .Page.Section -}}
+{{- $preRelease := .Site.Params.masterfolder -}}
+{{- if ne $pageSection $preRelease -}}
+  {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
+  {{- range .Site.Params.versions -}}
+    {{- if eq $pageSection .dirpath -}}
+      {{- $.Scratch.Set "release-version" .version -}}
+    {{- end -}}
+  {{- end -}}
+  {{/* If a patch value is specified then append that, otherwise use '.0' */}}
+  {{- if (.Get "patch") -}}
+    {{- $.Scratch.Add "release-version" (.Get "patch") -}}
+  {{- else -}}
+    {{- $.Scratch.Add "release-version" ".0" -}}
+  {{- end -}}
+  https://github.com/{{ $org }}/{{ $repo }}/releases/download/{{ $.Scratch.Get "release-version" }}/{{ $file }}
+{{- else -}}
+  {{- /* Use nightly if we don't match a version */ -}}
+  https://storage.googleapis.com/{{ $org }}-nightly/{{ $repo }}/latest/{{ $file }}
+{{- end -}}
+{{- /* This avoids a newline... */ -}}

--- a/layouts/shortcodes/artifact.html
+++ b/layouts/shortcodes/artifact.html
@@ -1,3 +1,14 @@
+{{/*
+
+Use this `artifact` shortcode to include the URL to a release artifact in
+a section of documentation.
+
+Parameters:
+* `org="knative"`: OPTIONAL, defaults to "knative".
+* `repo="serving"`: REQUIRED.  The repository within the given organization that is responsible for the published artifact.
+* `file="serving-core.yaml"`: REQUIRED.  The filename of the published artifact.
+
+*/}}
 {{- $org := trim (.Get "org") " " -}}
 {{- if not $org -}}
 {{- $org = "knative" -}}


### PR DESCRIPTION
This is used like:

```bash
kubectl apply --filename {{< artifact repo="serving" file="serving-crds.yaml" >}}
```

This will insert a link to the artifact attached to a github release for the selected release, or for "Pre-release" it should insert a link to the nightly builds on GCS.

Fixes: https://github.com/knative/website/issues/128

cc @samodell @RichieEscarez 