### PR TITLE
don't make active link bold

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -28,6 +28,7 @@
             padding: 0;
             margin: 0;
         }
+        font-size: $h6-font-size;
 
         @include media-breakpoint-up(md) {
             & > ul {
@@ -35,17 +36,16 @@
             }
         }
 
-
         padding-left: 0;
     }
 
     &__section-title {
         display: block;
+        font-size: $h5-font-size;
         font-weight: $font-weight-medium;
 
         .active {
-            font-weight: $font-weight-bold;
-            
+            color: $gray-900;
         }
 
         a {
@@ -70,7 +70,6 @@
         }
 
         &.active {
-            font-weight: $font-weight-bold;
             color:$knative-darker;
         }
     }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -15,7 +15,7 @@ $enable-shadows: false;
 $td-enable-google-fonts: true;
 
 // Knative colors
-$knative-darker: rgb(8, 101, 173);
+$knative-darker: rgb(0, 113, 199);
 $knative-lighter: rgb(102, 149, 202);
 
 // Theme colors


### PR DESCRIPTION
Problem: when a long section entry is active it wraps onto the next line, shifting the entire navbar
Proposal: don't use heavy weight font and make the color brighter.