### PR TITLE
Add noopener tags to links

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -19,7 +19,7 @@
           </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
-            <a class="btn btn-sm btn-secondary td-rss-button d-none d-lg-block" href="{{ .Permalink | safeURL }}" target="_blank">
+            <a class="btn btn-sm btn-secondary td-rss-button d-none d-lg-block" href="{{ .Permalink | safeURL }}" target="_blank" rel="noopener noreferrer">
               RSS <i class="fa fa-rss ml-2 "></i>
             </a>
             {{ end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -39,7 +39,7 @@
 <ul class="list-inline mb-0">
   {{ range . }}
   <li class="list-inline-item mx-2 h4" data-toggle="tooltip" data-placement="top" title="{{ .name }}">
-    <a class="text-white" target="_blank" href="{{ .url }}">
+    <a class="text-white" target="_blank" href="{{ .url }}" rel="noopener noreferrer">
       <i class="{{ .icon }}"></i>
     </a>
   </li>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -51,10 +51,10 @@
     {{ end }}
 
     {{ $editURL := printf "%s/tree/%s/%s" ($.Scratch.Get "gh_repo") ($.Scratch.Get "gh_branch") ($.Scratch.Get "filepath") }}
-    <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+    <a href="{{ $editURL }}" target="_blank" rel="noopener noreferrer"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 
     {{ $issuesURL := printf "%s/issues/new?title=%s(%s)&labels=kind%2Fbug&template=bug-in-existing-docs.md" ($.Scratch.Get "gh_repo") (htmlEscape $.Title) (htmlEscape $.Path) }}
-    <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+    <a href="{{ $issuesURL }}" target="_blank" rel="noopener noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 
     {{/* Determine the Knative component */}}
     {{ if or (eq $pageSection "docs") (eq $pageSection .Site.Params.masterfolder) }}


### PR DESCRIPTION
Adding the tags for `rel="noopener noreferrer"` to links that open new windows, to avoid potential leaking of the website DOM objects to 3rd party websites.