### PR TITLE
Revise build process to reduce amount of file moves and preparation

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,7 +1,24 @@
 <div class="td-content">
   <h1>{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
-  {{ .Content }}
+  {{ $out := .Content}}
+  {{ if not ( in (slice "README.md" "_index.md") .File.LogicalName ) }}
+    <!-- non-README.md files will be rendered one level below normal, fix links in them -->
+    {{ $out = $out | replaceRE "href=\"\\.\\./" "href=\"../../" }}
+    {{ $out = $out | replaceRE "href=\"\\./" "href=\"../"}}
+  {{ end }}
+  <!-- For SEO and aesthetics purposes, clean up GitHub URLs; this is
+       repeating the hugo "Pretty URLs" pattern on _relative_ links in the
+       source material.
+
+       The regexp ([^:\"]*(/[^\"]*)?) matches:
+       - Zero or more non-: or " charaters (: is needed for an absolute URL)
+       - Followed by a "/" and zero or more non " characters
+         (which would end the href attribute)
+       -->
+  {{ $out = $out | replaceRE "href=\"([^:\"]*(/[^\"]*)?)\\.md\"" "href=\"$1\""}}
+  {{ $out = $out | replaceRE "href=\"([^:\"]*(/[^\"]*)?)README\"" "href=\"$1\"" }}
+  {{ $out | safeHTML}}
   {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
     {{ partial "feedback.html" .Site.Params.ui.feedback }}
     <br />

--- a/scripts/convert-repo-ulrs.sh
+++ b/scripts/convert-repo-ulrs.sh
@@ -2,6 +2,9 @@
 # THIS FILE IS USED BY THE 'processsourcefiles.sh' SCRIPT TO CONVERT URLS TO RELATIVE #
 #######################################################################################
 
+# TODO(Evan): move this processing into golang, probably via
+# layouts/_default/content.html and/or shortcodes.
+
 echo '------ CONVERT FULLY QUALIFIED REPO URLS TO RELATIVE ------'
 # Convert fully-qualified URLs that are used in the Knative GitHub repos source files
 # to link from repo to repo, into relative URLs for publishing to the knative.dev site.


### PR DESCRIPTION
This is part 1 of a several-step process to move the site build mostly out of shell and into golang.

This produces three benefits:

1. The golang is probably more approachable for many developers.
2. The golang templates are applied when the content is rendered, which reduces the risk of corrupting static files, since they won't be rendered through the template.
3. When complete, it should be possible to use a static docker image with the website and map the "docs" directory into it for live iteration using the actual website rendering.

I've clicked around in multi-build mode a fair bit and this seems to work, but if there's a good way to actually diff the sites, I'd love to learn it.