### PR TITLE
Fix the Knative Slack link on the footer

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -75,7 +75,7 @@ breadcrumb_disable = false
         desc = "Development takes place here!"
 [[links.developer]]
   name = "Knative Slack channels"
-  url = "https://knative.slack.com/"
+  url = "https://slack.knative.dev/"
   external = "true"
   icon = "fab fa-slack"
         desc = "Chat with other project developers"


### PR DESCRIPTION
**What**

This PR changes the Slack link on the footer to https://slack.knative.dev/. By this, new users can visit to the invitation page.

**Why**

Currently, the Slack link on the footer refers to https://knative.slack.com/ instead of https://slack.knative.dev/. This causes new users to the login page of the Slack channel but they didn't sign up the channel and cannot sign in.

**Related**

#111 fixes the same problem for the Slack link on the home page. This PR apply the same change to the Slack link on the footer.
