### PR TITLE
Update golang vanity url for operator move to core.

### DIFF
--- a/static/golang/operator.html
+++ b/static/golang/operator.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/operator git https://github.com/knative-sandbox/operator">
-    <meta name="go-source" content="knative.dev/operator     https://github.com/knative-sandbox/operator https://github.com/knative-sandbox/operator/tree/master{/dir} https://github.com/knative-sandbox/operator/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/operator git https://github.com/knative/operator">
+    <meta name="go-source" content="knative.dev/operator     https://github.com/knative/operator https://github.com/knative/operator/tree/master{/dir} https://github.com/knative/operator/blob/master{/dir}/{file}#L{line}">
 </head></html>


### PR DESCRIPTION
As per title. We're moving the combined operator (knative-sandbox/operator) into the core repositories.