### PR TITLE
add eventing-autoscaler-keda redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -3,6 +3,7 @@
 /client/* go-get=1 /golang/client.html 200
 /discovery/* go-get=1 /golang/discovery.html 200
 /eventing/* go-get=1 /golang/eventing.html 200
+/eventing-autoscaler-keda/* go-get=1 /golang/eventing-autoscaler-keda.html 200
 /eventing-contrib/* go-get=1 /golang/eventing-contrib.html 200
 /eventing-kafka/* go-get=1 /golang/eventing-kafka.html 200
 /eventing-kafka-broker/* go-get=1 /golang/eventing-kafka-broker.html 200

--- a/static/golang/eventing-autoscaler-keda.html
+++ b/static/golang/eventing-autoscaler-keda.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/eventing-autoscaler-keda git https://github.com/knative-sandbox/eventing-autoscaler-keda">
+    <meta name="go-source" content="knative.dev/eventing-autoscaler-keda     https://github.com/knative-sandbox/eventing-autoscaler-keda https://github.com/knative-sandbox/eventing-autoscaler-keda/tree/master{/dir} https://github.com/knative-sandbox/eventing-autoscaler-keda/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
A new repo for Knative Eventing Sources Autoscaler was created: https://github.com/knative-sandbox/eventing-autoscaler-keda

Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>