### PR TITLE
Clean up Hugo deprecation warnings.

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -5,9 +5,9 @@
 
 @import "../vendor/bootstrap/scss/bootstrap";
 
-@import "../vendor/Font-Awesome//web-fonts-with-css/scss/fontawesome.scss";
-@import "../vendor/Font-Awesome//web-fonts-with-css/scss/fa-solid.scss";
-@import "../vendor/Font-Awesome//web-fonts-with-css/scss/fa-brands.scss";
+@import "../vendor/Font-Awesome/scss/fontawesome.scss";
+@import "../vendor/Font-Awesome/scss/solid.scss";
+@import "../vendor/Font-Awesome/scss/brands.scss";
 
 @import "support/utilities";
 @import "colors";

--- a/layouts/partials/blogwelcome.html
+++ b/layouts/partials/blogwelcome.html
@@ -1,29 +1,29 @@
-{{ if (in .Dir "releases") }}
+{{ if (in .File.Dir "releases") }}
 {{ $.Scratch.Set "blogsection" "Knative releases"}}
-{{ else if (in .Dir "articles") }}
+{{ else if (in .File.Dir "articles") }}
 {{ $.Scratch.Set "blogsection" "Knative articles"}}
-{{ else if (in .Dir "events") }}
+{{ else if (in .File.Dir "events") }}
 {{ $.Scratch.Set "blogsection" "Knative social events"}}
 {{ else }}
 {{ $.Scratch.Set "blogsection" "Welcome to the Knative blog"}}
 {{ end }}
 
 <h1>{{ $.Scratch.Get "blogsection" }}</h1>
-{{ if eq .Dir "blog/" }}
+{{ if eq .File.Dir "blog/" }}
 <p>Follow this blog to keep up-to-date with Knative.</p>
 <ul>
 <li><a href="./releases"><b>Release and feature announcements</b></a>: <br>{{ end }}
-{{ if or (in .Dir "releases") (eq .Dir "blog/") }}Learn about each Knative release, what's new and changed, and how to get started with the latest and greatest.{{ end }}
+{{ if or (in .File.Dir "releases") (eq .File.Dir "blog/") }}Learn about each Knative release, what's new and changed, and how to get started with the latest and greatest.{{ end }}
 
-{{ if eq .Dir "blog/" }}</li>
+{{ if eq .File.Dir "blog/" }}</li>
 <li><a href="./articles"><b>Articles</b></a>: <br>{{ end }}
-{{ if or (in .Dir "articles") (eq .Dir "blog/") }}Read about Knative-centric features, tools, and related topics.{{ end }}
+{{ if or (in .File.Dir "articles") (eq .File.Dir "blog/") }}Read about Knative-centric features, tools, and related topics.{{ end }}
 
-{{ if eq .Dir "blog/" }}</li>
+{{ if eq .File.Dir "blog/" }}</li>
 <li><a href="./events"><b>Future and past social events</b></a>: <br>{{ end }}
-{{ if or (in .Dir "events") (eq .Dir "blog/") }}Find out where the Knative team will be talking next, and where they've been.{{ end }}
+{{ if or (in .File.Dir "events") (eq .File.Dir "blog/") }}Find out where the Knative team will be talking next, and where they've been.{{ end }}
 
-{{ if eq .Dir "blog/" }}</li>
+{{ if eq .File.Dir "blog/" }}</li>
 </ul>
 <hr>
 <p><b>Browse all Knative blog posts by date:</b></p>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -72,14 +72,14 @@
 
     {{/* BLOG section - Show Post link */}}
     {{ else if (eq $pageSection "blog")}}
-    {{ if eq .Dir "blog/" }}
+    {{ if eq .File.Dir "blog/" }}
     {{ $.Scratch.Set "blogsec" "Knative " }}
     {{ else }}
-    {{ $getfolder := (replace (printf "%s" .Dir) "blog/" "" ) }}
+    {{ $getfolder := (replace (printf "%s" .File.Dir) "blog/" "" ) }}
     {{ $getfolder := (replace (printf "%s" $getfolder) "/" " " ) }}
     {{ $.Scratch.Set "blogsec" $getfolder }}
     {{ end }}
-    <a href="https://github.com/knative/docs/new/master/{{ .Dir }}" target="_blank"><i class="fab fa-github fa-fw"></i>Post to the {{ $.Scratch.Get "blogsec" }}blog</a>
+    <a href="https://github.com/knative/docs/new/master/{{ .File.Dir }}" target="_blank"><i class="fab fa-github fa-fw"></i>Post to the {{ $.Scratch.Get "blogsec" }}blog</a>
     {{ end }}
   </div>
   {{ end }}

--- a/layouts/shortcodes/readfile.md
+++ b/layouts/shortcodes/readfile.md
@@ -92,7 +92,7 @@ Parameters:
 {{ else }}
 
 {{/* Make relative: Fetch the current directory and then append it to the specified `file=""` value */}}
-{{ $.Scratch.Set "filepath" $.Page.Dir }}
+{{ $.Scratch.Set "filepath" $.Page.File.Dir }}
 {{ $.Scratch.Add "filepath" ( .Get "file" ) }}
 
 {{ end }}


### PR DESCRIPTION
Fixes the following warnings, updates to the latest version of the Docsy theme
```
WARN 2020/08/04 14:26:46 Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2020/08/04 14:26:46 Page.Dir is deprecated and will be removed in a future release. Use .File.Dir

  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```