### PR TITLE
update build files for release 0.17

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -3,11 +3,12 @@
 
 ########################
 # Default site parameters
+# RELEASE-ITEM: 'latest_github_branch' and 'version' get updated each release
 
 # GitHub branch (latest release)
-latest_github_branch = "release-0.16"
+latest_github_branch = "release-0.17"
 # Default version (latest release)
-version = "v0.16"
+version = "v0.17"
 ########################
 
 # Section labels for versions

--- a/config/local/params.toml
+++ b/config/local/params.toml
@@ -15,9 +15,9 @@ releaselabel = "Local Preview Build: "
 # Local build version
 ################
 # Set to "docs" path
-
+# RELEASE-ITEM: 'version' gets updated each release
 [[versions]]
-  version = "v0.16"
+  version = "v0.17"
   ghbranchname = "master"
   url = "/docs/"
   dirpath = "docs"

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -34,19 +34,26 @@ no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues
 #             where # is the MAJOR and MINOR semantic version values
 
 # Latest version
+# RELEASE-ITEM: 'version' and 'ghbranchname' get updated each release
 ################
 # Set to "docs" path
 
 [[versions]]
-  version = "v0.16"
-  ghbranchname = "release-0.16"
+  version = "v0.17"
+  ghbranchname = "release-0.17"
   url = "/docs/"
   dirpath = "docs"
 
 # Archived versions
+# RELEASE-ITEM: All version #'s get updated each release
 ###################
 # Prefix all past versions with release # "v#.#-docs"
 
+[[versions]]
+  version = "v0.16"
+  ghbranchname = "release-0.16"
+  url = "/v0.16-docs/"
+  dirpath = "v0.16-docs"
 [[versions]]
   version = "v0.15"
   ghbranchname = "release-0.15"
@@ -57,11 +64,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues
   ghbranchname = "release-0.14"
   url = "/v0.14-docs/"
   dirpath = "v0.14-docs"
-[[versions]]
-  version = "v0.13"
-  ghbranchname = "release-0.13"
-  url = "/v0.13-docs/"
-  dirpath = "v0.13-docs"
 
 [[versions]]
   version = "Archives"

--- a/config/staging/params.toml
+++ b/config/staging/params.toml
@@ -14,9 +14,9 @@ doclabel = "Pull Request Preview: "
 releaselabel = "Pull Request Preview: "
 
 # Set PRs to build to the "docs" path
-
+# RELEASE-ITEM: 'version' gets updated each release
 [[versions]]
-  version = "v0.16"
+  version = "v0.17"
   ghbranchname = "master"
   url = "/docs/"
   dirpath = "docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@
 # Site redirects
 
 ################
-# RELEASE-ITEM: Add new and archive old versions each release
+# RELEASE-ITEM: For each release, add new/latest release and archive versions older than latest-3
 
 # Update to the latest version number
 # Enable permanent links to a new release (so links persist after release is archived)

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,12 +16,12 @@
 # Site redirects
 
 ################
-# These should be updated each release 
+# RELEASE-ITEM: Add new and archive old versions each release
 
 # Update to the latest version number
-# Enable permanent links to a release (link persists after release is archived)
+# Enable permanent links to a new release (so links persist after release is archived)
 [[redirects]]
-  from = "/v0.16-docs/*"
+  from = "/v0.17-docs/*"
   to = "/docs/:splat"
   status = 200
 
@@ -29,6 +29,11 @@
 # We publish LATEST -3 versions to knative.dev, all older versions get redirect
 # back to the latest version in case old bookmarks or articles still point to 
 # one of those "previously published" versions 
+
+[[redirects]]
+  from = "/v0.13-docs/*"
+  to = "/docs/"
+  status = 301
 
 [[redirects]]
   from = "/v0.12-docs/*"

--- a/scripts/docs-version-settings.sh
+++ b/scripts/docs-version-settings.sh
@@ -4,8 +4,16 @@
 # THE DEFAULT DOCS REPO AND VERSION SETTINGS #
 ##############################################
 
-# This should be set to the latest docs release/branch
-DEFAULTBRANCH="release-0.16"
+# Version number of the latest release
+# RELEASE-ITEM: This gets updated every release
+LATESTVERSION="17"
+
+# Branch name of the latest release
+DEFAULTBRANCH="release-0.$LATESTVERSION"
+
+# Total number of past versions to publish
+NUMOFVERSIONS="3"
+OLDESTVERSION=$((LATESTVERSION-NUMOFVERSIONS))
 
 # An optional value that you can locally override for local builds/testing
 DEFAULTFORK="knative"

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -31,24 +31,25 @@ then
   # DOCS BRANCHES
   echo '------ Cloning all docs releases ------'
   # Get versions of released docs from their branches in "$FORK"/docs
-  echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"
-  # Latest version is defined in website/scripts/docs-version-settings.sh
+  # Versions are defined in website/scripts/docs-version-settings.sh
   # If this is a PR build, then build that content as the latest release (assume PR preview builds are always from "latest")
-  git clone --quiet -b "$BRANCH" https://github.com/"$FORK"/docs.git temp/release/latest
-  # Only copy and keep the "docs" folder from all branched releases:
-  mv temp/release/latest/docs content/en/docs
   echo 'Getting the archived docs releases from branches in:' "$FORK"'/docs'
-    ###############################################################
-    # Template for next release:
-    #git clone -b "release-[VERSION#]" https://github.com/"$FORK"/docs.git temp/release/[VERSION#]
-    #mv temp/release/[VERSION#]/docs content/en/[VERSION#]-docs
-    ###############################################################
-  git clone --quiet -b "release-0.15" https://github.com/"$FORK"/docs.git temp/release/v0.15
-  mv temp/release/v0.15/docs content/en/v0.15-docs
-  git clone --quiet -b "release-0.14" https://github.com/"$FORK"/docs.git temp/release/v0.14
-  mv temp/release/v0.14/docs content/en/v0.14-docs
-  git clone --quiet -b "release-0.13" https://github.com/"$FORK"/docs.git temp/release/v0.13
-  mv temp/release/v0.13/docs content/en/v0.13-docs
+  r=$OLDESTVERSION
+  while [[ $r -le $LATESTVERSION ]]
+  do
+    CLONE="temp/release-0.${r}"
+    echo 'Getting docs from: release-0.'"${r}"
+    git clone --quiet -b "release-0.${r}" "https://github.com/${FORK}/docs.git" "$CLONE"
+    if [ "$r" = "$LATESTVERSION" ]
+    then
+      echo 'The /docs/ section is built from:' "$FORK"'/release-0.'"${r}"
+      mv "$CLONE"/docs content/en/docs
+    else
+      # Only use the "docs" folder from all branches/releases
+      mv "$CLONE"/docs content/en/v0."$r"-docs
+    fi
+    (( r = r + 1 ))
+  done
 
 elif [ "$BUILDSINGLEBRANCH" = "true" ]
 then


### PR DESCRIPTION
Update knative.dev site build to include new release-0.17 branch. Also:

- Added/copied an enhancement i added in #155, into our current build to reduce the number of files we need to touch for each new release (for the time being until the many improvements mentioned in #155+ get implemented)

- Add "searchable" labels/flags to indicate what and where version numbers need updating each release