### PR TITLE
Remove master references where possible.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -15,9 +15,9 @@ version = "v0.14"
 doclabel = "Documentation "
 releaselabel = "Release: "
 # Pre-release
-masterlabel = "Pre-release"
-# section path value ("master" docs directory folder on website)
-masterfolder = "development"
+prereleaselabel = "Pre-release"
+# section path value ("development" docs directory folder on website)
+prereleasefolder = "development"
 
 # Footer content
 knativeAuthors = "The Knative Authors"

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,8 +1,8 @@
 {{/* Prefix labels for menus */}}
 {{ $.Scratch.Set "docLabel" .Site.Params.doclabel }}
 {{ $.Scratch.Set "releaseLabel" .Site.Params.releaselabel }}
-{{ $masterMainLabel := .Site.Params.masterlabel }}
-{{ $masterDropLabel := .Site.Params.masterfolder }}
+{{ $preReleaseLabel := .Site.Params.prereleaselabel }}
+{{ $preReleaseDropLabel := .Site.Params.prereleasefolder }}
 
 {{/* set defaults for version and dropdown menu highlighting */}}
 {{ $.Scratch.Set "activeVersion" .Site.Params.version }}
@@ -16,10 +16,10 @@
 {{ range .Site.Params.versions }}
   {{ if eq $curPage .dirpath }}
 
-    {{ if eq $curPage $masterDropLabel }}
-      {{/* pre-release content (master branch) */}}
-      {{ $.Scratch.Set "docLabel" $masterMainLabel }}
-      {{ $.Scratch.Set "releaseLabel" $masterMainLabel }}
+    {{ if eq $curPage $preReleaseDropLabel }}
+      {{/* pre-release content */}}
+      {{ $.Scratch.Set "docLabel" $preReleaseLabel }}
+      {{ $.Scratch.Set "releaseLabel" $preReleaseLabel }}
     {{ else }}
       {{/* released version */}}
       {{ $.Scratch.Add "docLabel" " " }}
@@ -41,6 +41,6 @@
   {{ range .Site.Params.versions }}
   <a
   class="dropdown-item{{ if eq ( $.Scratch.Get "activeVersion" ) ( printf "%s" .version ) }} active{{ end }}"
-  style="{{ if eq .version $masterMainLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
+  style="{{ if eq .version $preReleaseLabel }}color:#BCBCBC{{ end }}" href="{{ .url }}">{{ .version }}</a>
   {{ end }}
 </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
-{{ $master := .Site.Params.masterfolder}}
+{{ $prerelease := .Site.Params.prereleasefolder}}
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     <span class="navbar-logo">{{ with resources.Get "/icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }} {{ end }}</span>
@@ -8,7 +8,7 @@
   <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
     <ul class="navbar-nav mt-2 mt-lg-0">
       {{/* Display doc version selector menu for "docs" or "v#.#-docs" sections */}}
-      {{ if or (in .Page.Section "docs") (in .Page.Section $master) }}
+      {{ if or (in .Page.Section "docs") (in .Page.Section $prerelease) }}
       <li class="nav-item dropdown d-none d-lg-block">
         {{ partial "navbar-version-selector.html" . }}
       </li>
@@ -24,7 +24,7 @@
         {{ if and (in $p.Section "docs") (eq .Name "Documentation") }}
         	{{ $.Scratch.Set "showdoclink" "false"}}
         {{ end }}
-        {{ if and (eq $p.Section $master) (eq .Name "Documentation") }}
+        {{ if and (eq $p.Section $prerelease) (eq .Name "Documentation") }}
         	{{ $.Scratch.Set "showdoclink" "false"}}
         {{ end }}
         {{ if eq (printf "%s" ($.Scratch.Get "showdoclink")) "true" }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,6 +1,6 @@
 {{/* Show only on production site (not local builds since we can't determine version) */}}
 {{ if not .Site.IsServer }}
-{{ $master := .Site.Params.masterfolder }}
+{{ $prerelease := .Site.Params.prereleasefolder }}
 {{ if .Path }}
   {{/* Set default values */}}
   {{ $pageSection := .Page.Section }}
@@ -13,9 +13,8 @@
   {{ if in $pageSection "docs" }}
     {{ $.Scratch.Set "filepath" (replaceRE "v[0-9].[0-9]-docs" "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
   {{ end }}
-  {{/* Point to 'master' for pre-release content */}}
-  {{ if eq $pageSection $master }}
-   {{ $.Scratch.Set "filepath" (replaceRE (printf "%s" $master) "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
+  {{ if eq $pageSection $prerelease }}
+   {{ $.Scratch.Set "filepath" (replaceRE (printf "%s" $prerelease) "docs" (printf "%s" ($.Scratch.Get "filepath"))) }}
   {{ end }}
   {{/* Remove the "contributing" from path for knative/community content */}}
   {{ if in $pageSection "contributing" }}
@@ -57,7 +56,7 @@
     <a href="{{ $issuesURL }}" target="_blank" rel="noopener noreferrer"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 
     {{/* Determine the Knative component */}}
-    {{ if or (eq $pageSection "docs") (eq $pageSection .Site.Params.masterfolder) }}
+    {{ if or (eq $pageSection "docs") (eq $pageSection .Site.Params.prereleasefolder) }}
       {{ if in (printf "%s" ($.Scratch.Get "filepath")) "/serving/" }}
         {{ $.Scratch.Set "gh_repo" (printf "%s/issues/new" ($.Param "github_servingrepo")) }}
       {{ end }}

--- a/layouts/shortcodes/artifact.html
+++ b/layouts/shortcodes/artifact.html
@@ -16,7 +16,7 @@ Parameters:
 {{- $repo := trim (.Get "repo") " " -}}
 {{- $file := trim (.Get "file") " " -}}
 {{- $pageSection := .Page.Section -}}
-{{- $preRelease := .Site.Params.masterfolder -}}
+{{- $preRelease := .Site.Params.prereleasefolder -}}
 {{- if ne $pageSection $preRelease -}}
   {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
   {{- range .Site.Params.versions -}}

--- a/layouts/shortcodes/version.md
+++ b/layouts/shortcodes/version.md
@@ -2,12 +2,12 @@
 {{- $pageSection := .Page.Section -}}
 {{/* Get latest release and the name of the pre-release section */}}
 {{- $.Scratch.Set "release-version" .Site.Params.version -}}
-{{- $preRelease := .Site.Params.masterfolder -}}
+{{- $preRelease := .Site.Params.prereleasefolder -}}
 {{/* Use the specified version override (not directory based) */}}
 {{- if (.Get "override") -}}
   {{- $.Scratch.Set "release-version" (.Get "override") -}}
 {{- else -}}
-  {{/* Keep using the latest version for the "pre-release" content (masterfolder) */}}
+  {{/* Keep using the latest version for the "pre-release" content (prereleasefolder) */}}
   {{- if ne $pageSection $preRelease -}}
     {{/* Use version based on the directory path (see .dirpath in config/_default/params.toml) */}}
     {{- range .Site.Params.versions -}}


### PR DESCRIPTION
`master` mostly means "pre-release" from the website's PoV, so let's name it accordingly.