### PR TITLE
Move hidden files

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -22,7 +22,10 @@ ignoreFiles = [
   "README.md$",
   "/*/reference/api/serving.md",
   "/*/reference/api/eventing/eventing.md",
-  "/*/reference/api/eventing/eventing-contrib.md" ]
+  "/*/reference/api/eventing/eventing-contrib.md",
+  "/*/reference/serving.md",
+  "/*/reference/eventing/eventing.md",
+  "/*/reference/eventing/eventing-contrib.md" ]
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -20,12 +20,9 @@ relativeURLs = "true"
 # (the README.md files are kept for GitHub repo users so a landing pages appears)
 ignoreFiles = [
   "README.md$",
-  "/*/reference/build.md",
-  "/*/reference/serving.md",
-  "/*/reference/eventing/eventing.md",
-  "/*/reference/eventing/eventing-contrib.md",
-  "/*/reference/eventing/eventing-sources.md",
-  "/*/reference/eventing/eventing-contrib-resources.md" ]
+  "/*/reference/api/serving.md",
+  "/*/reference/api/eventing/eventing.md",
+  "/*/reference/api/eventing/eventing-contrib.md" ]
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]


### PR DESCRIPTION
To align with the Ref section restructure in https://github.com/knative/docs/pull/2806, need to add the new directory to make sure hidden files do not show in the TOC (and leave old directories to continue supporting the published set of archives).

Also removed old files.

This PR depends on https://github.com/knative/docs/pull/2806
