### PR TITLE
Add knative.dev/kperf golang redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -18,6 +18,7 @@
 /eventing-operator/* go-get=1 /golang/eventing-operator.html 200
 /eventing-prometheus/* go-get=1 /golang/eventing-prometheus.html 200
 /eventing-rabbitmq/* go-get=1 /golang/eventing-rabbitmq.html 200
+/kperf/* go-get=1 /golang/kperf.html 200
 /observability/* go-get=1 /golang/observability.html 200
 /operator/* go-get=1 /golang/operator.html 200
 /networking/* go-get=1 /golang/networking.html 200

--- a/static/golang/kperf.html
+++ b/static/golang/kperf.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/kperf git https://github.com/knative-sandbox/kperf">
+    <meta name="go-source" content="knative.dev/kperf     https://github.com/knative-sandbox/kperf https://github.com/knative-sandbox/kperf/tree/master{/dir} https://github.com/knative-sandbox/kperf/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
Followed discussion here and raised this PR https://github.com/knative/community/issues/211

One question: should we use `knative.dev` for the project under` knative-sandbox`? 
I followed the sample in the issue above to use `knative.dev`, please let me know if this needs an update. Thanks!

CC @mattmoor @chizhg @maximilien 