### PR TITLE
fix redirects to knative-sandbox

### DIFF
--- a/static/golang/eventing-camel.html
+++ b/static/golang/eventing-camel.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-camel git https://github.com/knative/eventing-camel">
-    <meta name="go-source" content="knative.dev/eventing-camel     https://github.com/knative/eventing-camel https://github.com/knative/eventing-camel/tree/master{/dir} https://github.com/knative/eventing-camel/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-camel git https://github.com/knative-sandbox/eventing-camel">
+    <meta name="go-source" content="knative.dev/eventing-camel     https://github.com/knative-sandbox/eventing-camel https://github.com/knative-sandbox/eventing-camel/tree/master{/dir} https://github.com/knative-sandbox/eventing-camel/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/eventing-ceph.html
+++ b/static/golang/eventing-ceph.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-ceph git https://github.com/knative/eventing-ceph">
-    <meta name="go-source" content="knative.dev/eventing-ceph     https://github.com/knative/eventing-ceph https://github.com/knative/eventing-ceph/tree/master{/dir} https://github.com/knative/eventing-ceph/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-ceph git https://github.com/knative-sandbox/eventing-ceph">
+    <meta name="go-source" content="knative.dev/eventing-ceph     https://github.com/knative-sandbox/eventing-ceph https://github.com/knative-sandbox/eventing-ceph/tree/master{/dir} https://github.com/knative-sandbox/eventing-ceph/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/eventing-couchdb.html
+++ b/static/golang/eventing-couchdb.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-couchdb git https://github.com/knative/eventing-couchdb">
-    <meta name="go-source" content="knative.dev/eventing-couchdb     https://github.com/knative/eventing-couchdb https://github.com/knative/eventing-couchdb/tree/master{/dir} https://github.com/knative/eventing-couchdb/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-couchdb git https://github.com/knative-sandbox/eventing-couchdb">
+    <meta name="go-source" content="knative.dev/eventing-couchdb     https://github.com/knative-sandbox/eventing-couchdb https://github.com/knative-sandbox/eventing-couchdb/tree/master{/dir} https://github.com/knative-sandbox/eventing-couchdb/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/eventing-github.html
+++ b/static/golang/eventing-github.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-github git https://github.com/knative/eventing-github">
-    <meta name="go-source" content="knative.dev/eventing-github     https://github.com/knative/eventing-github https://github.com/knative/eventing-github/tree/master{/dir} https://github.com/knative/eventing-github/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-github git https://github.com/knative-sandbox/eventing-github">
+    <meta name="go-source" content="knative.dev/eventing-github     https://github.com/knative-sandbox/eventing-github https://github.com/knative-sandbox/eventing-github/tree/master{/dir} https://github.com/knative-sandbox/eventing-github/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/eventing-gitlab.html
+++ b/static/golang/eventing-gitlab.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-gitlab git https://github.com/knative/eventing-gitlab">
-    <meta name="go-source" content="knative.dev/eventing-gitlab     https://github.com/knative/eventing-gitlab https://github.com/knative/eventing-gitlab/tree/master{/dir} https://github.com/knative/eventing-gitlab/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-gitlab git https://github.com/knative-sandbox/eventing-gitlab">
+    <meta name="go-source" content="knative.dev/eventing-gitlab     https://github.com/knative-sandbox/eventing-gitlab https://github.com/knative-sandbox/eventing-gitlab/tree/master{/dir} https://github.com/knative-sandbox/eventing-gitlab/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/eventing-prometheus.html
+++ b/static/golang/eventing-prometheus.html
@@ -1,4 +1,4 @@
 <html><head>
-    <meta name="go-import" content="knative.dev/eventing-prometheus git https://github.com/knative/eventing-prometheus">
-    <meta name="go-source" content="knative.dev/eventing-prometheus     https://github.com/knative/eventing-prometheus https://github.com/knative/eventing-prometheus/tree/master{/dir} https://github.com/knative/eventing-prometheus/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/eventing-prometheus git https://github.com/knative-sandbox/eventing-prometheus">
+    <meta name="go-source" content="knative.dev/eventing-prometheus     https://github.com/knative-sandbox/eventing-prometheus https://github.com/knative-sandbox/eventing-prometheus/tree/master{/dir} https://github.com/knative-sandbox/eventing-prometheus/blob/master{/dir}/{file}#L{line}">
 </head></html>


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

i ran into a redirect issue with the knative.dev site.
when running:
```
go get knative.dev/eventing-ceph
```
it tries to call:
```
git clone -- https://github.com/knative/eventing-ceph
```
instead of:
```
git clone -- https://github.com/knative-sandbox/eventing-ceph
```

similar issue happened for other repos as well.