### PR TITLE
Write a tool to automatically fill out the go mod redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,8 +1,21 @@
+/community/contributing/working-groups /community/contributing/working-groups/working-groups 301
+
+# The following lines are AUTO-GENERATED
+#
+# DO NOT EDIT!
+#
+# To regenerate, run:
+#   ./tools/redir-gen/redir-gen
 /async-component/* go-get=1 /golang/async-component.html 200
-/build/* go-get=1 /golang/build.html 200
+/build-spike/* go-get=1 /golang/build-spike.html 200
 /caching/* go-get=1 /golang/caching.html 200
 /client/* go-get=1 /golang/client.html 200
+/client-contrib/* go-get=1 /golang/client-contrib.html 200
+/community/* go-get=1 /golang/community.html 200
 /discovery/* go-get=1 /golang/discovery.html 200
+/docs/* go-get=1 /golang/docs.html 200
+/downstream-test-go/* go-get=1 /golang/downstream-test-go.html 200
+/eventing/* go-get=1 /golang/eventing.html 200
 /eventing-autoscaler-keda/* go-get=1 /golang/eventing-autoscaler-keda.html 200
 /eventing-awssqs/* go-get=1 /golang/eventing-awssqs.html 200
 /eventing-camel/* go-get=1 /golang/eventing-camel.html 200
@@ -11,15 +24,15 @@
 /eventing-couchdb/* go-get=1 /golang/eventing-couchdb.html 200
 /eventing-github/* go-get=1 /golang/eventing-github.html 200
 /eventing-gitlab/* go-get=1 /golang/eventing-gitlab.html 200
-/eventing-kafka-broker/* go-get=1 /golang/eventing-kafka-broker.html 200
 /eventing-kafka/* go-get=1 /golang/eventing-kafka.html 200
+/eventing-kafka-broker/* go-get=1 /golang/eventing-kafka-broker.html 200
 /eventing-natss/* go-get=1 /golang/eventing-natss.html 200
-/eventing-operator/* go-get=1 /golang/eventing-operator.html 200
 /eventing-prometheus/* go-get=1 /golang/eventing-prometheus.html 200
 /eventing-rabbitmq/* go-get=1 /golang/eventing-rabbitmq.html 200
 /eventing-redis/* go-get=1 /golang/eventing-redis.html 200
-/eventing/* go-get=1 /golang/eventing.html 200
 /hack/* go-get=1 /golang/hack.html 200
+/homebrew-client/* go-get=1 /golang/homebrew-client.html 200
+/integration/* go-get=1 /golang/integration.html 200
 /kn-plugin-admin/* go-get=1 /golang/kn-plugin-admin.html 200
 /kperf/* go-get=1 /golang/kperf.html 200
 /net-certmanager/* go-get=1 /golang/net-certmanager.html 200
@@ -28,13 +41,12 @@
 /net-istio/* go-get=1 /golang/net-istio.html 200
 /net-kourier/* go-get=1 /golang/net-kourier.html 200
 /networking/* go-get=1 /golang/networking.html 200
-/observability/* go-get=1 /golang/observability.html 200
 /operator/* go-get=1 /golang/operator.html 200
 /pkg/* go-get=1 /golang/pkg.html 200
 /reconciler-test/* go-get=1 /golang/reconciler-test.html 200
 /sample-controller/* go-get=1 /golang/sample-controller.html 200
 /sample-source/* go-get=1 /golang/sample-source.html 200
-/serving-operator/* go-get=1 /golang/serving-operator.html 200
 /serving/* go-get=1 /golang/serving.html 200
 /test-infra/* go-get=1 /golang/test-infra.html 200
-/community/contributing/working-groups /community/contributing/working-groups/working-groups 301
+/website/* go-get=1 /golang/website.html 200
+/wg-repository/* go-get=1 /golang/wg-repository.html 200

--- a/static/golang/async-component.html
+++ b/static/golang/async-component.html
@@ -1,4 +1,4 @@
 <html><head>
-  <meta name="go-import" content="knative.dev/async-component git https://github.com/knative-sandbox/async-component">
-  <meta name="go-source" content="knative.dev/async-component     https://github.com/knative-sandbox/async-component https://github.com/knative-sandbox/async-component/tree/master{/dir} https://github.com/knative-sandbox/async-component/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="knative.dev/async-component git https://github.com/knative-sandbox/async-component">
+    <meta name="go-source" content="knative.dev/async-component     https://github.com/knative-sandbox/async-component https://github.com/knative-sandbox/async-component/tree/master{/dir} https://github.com/knative-sandbox/async-component/blob/master{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/build-spike.html
+++ b/static/golang/build-spike.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/build-spike git https://github.com/knative-sandbox/build-spike">
+    <meta name="go-source" content="knative.dev/build-spike     https://github.com/knative-sandbox/build-spike https://github.com/knative-sandbox/build-spike/tree/master{/dir} https://github.com/knative-sandbox/build-spike/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/build.html
+++ b/static/golang/build.html
@@ -1,4 +1,0 @@
-<html><head>
-    <meta name="go-import" content="knative.dev/build git https://github.com/knative/build">
-    <meta name="go-source" content="knative.dev/build     https://github.com/knative/build https://github.com/knative/build/tree/master{/dir} https://github.com/knative/build/blob/master{/dir}/{file}#L{line}">
-</head></html>

--- a/static/golang/client-contrib.html
+++ b/static/golang/client-contrib.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/client-contrib git https://github.com/knative/client-contrib">
+    <meta name="go-source" content="knative.dev/client-contrib     https://github.com/knative/client-contrib https://github.com/knative/client-contrib/tree/master{/dir} https://github.com/knative/client-contrib/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/community.html
+++ b/static/golang/community.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/community git https://github.com/knative/community">
+    <meta name="go-source" content="knative.dev/community     https://github.com/knative/community https://github.com/knative/community/tree/master{/dir} https://github.com/knative/community/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/docs.html
+++ b/static/golang/docs.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/docs git https://github.com/knative/docs">
+    <meta name="go-source" content="knative.dev/docs     https://github.com/knative/docs https://github.com/knative/docs/tree/master{/dir} https://github.com/knative/docs/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/downstream-test-go.html
+++ b/static/golang/downstream-test-go.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/downstream-test-go git https://github.com/knative-sandbox/downstream-test-go">
+    <meta name="go-source" content="knative.dev/downstream-test-go     https://github.com/knative-sandbox/downstream-test-go https://github.com/knative-sandbox/downstream-test-go/tree/master{/dir} https://github.com/knative-sandbox/downstream-test-go/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/eventing-operator.html
+++ b/static/golang/eventing-operator.html
@@ -1,4 +1,0 @@
-<html><head>
-    <meta name="go-import" content="knative.dev/eventing-operator git https://github.com/knative/eventing-operator">
-    <meta name="go-source" content="knative.dev/eventing-operator     https://github.com/knative/eventing-operator https://github.com/knative/eventing-operator/tree/master{/dir} https://github.com/knative/eventing-operator/blob/master{/dir}/{file}#L{line}">
-</head></html>

--- a/static/golang/homebrew-client.html
+++ b/static/golang/homebrew-client.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/homebrew-client git https://github.com/knative/homebrew-client">
+    <meta name="go-source" content="knative.dev/homebrew-client     https://github.com/knative/homebrew-client https://github.com/knative/homebrew-client/tree/master{/dir} https://github.com/knative/homebrew-client/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/integration.html
+++ b/static/golang/integration.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/integration git https://github.com/knative-sandbox/integration">
+    <meta name="go-source" content="knative.dev/integration     https://github.com/knative-sandbox/integration https://github.com/knative-sandbox/integration/tree/master{/dir} https://github.com/knative-sandbox/integration/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/observability.html
+++ b/static/golang/observability.html
@@ -1,4 +1,0 @@
-<html><head>
-    <meta name="go-import" content="knative.dev/observability git https://github.com/knative/observability">
-    <meta name="go-source" content="knative.dev/observability     https://github.com/knative/observability https://github.com/knative/observability/tree/master{/dir} https://github.com/knative/observability/blob/master{/dir}/{file}#L{line}">
-</head></html>

--- a/static/golang/sample-controller.html
+++ b/static/golang/sample-controller.html
@@ -1,4 +1,4 @@
 <html><head>
     <meta name="go-import" content="knative.dev/sample-controller git https://github.com/knative-sandbox/sample-controller">
-    <meta name="go-source" content="knative.dev/sample-controller     https://github.com/knative-sandbox/sample-controller https://github.com/knative-sandbox/sample-controller/tree/master{/dir} https://github.com/knative-sandbox/sample-controller/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-source" content="knative.dev/sample-controller     https://github.com/knative-sandbox/sample-controller https://github.com/knative-sandbox/sample-controller/tree/main{/dir} https://github.com/knative-sandbox/sample-controller/blob/main{/dir}/{file}#L{line}">
 </head></html>

--- a/static/golang/serving-operator.html
+++ b/static/golang/serving-operator.html
@@ -1,4 +1,0 @@
-<html><head>
-    <meta name="go-import" content="knative.dev/serving-operator git https://github.com/knative/serving-operator">
-    <meta name="go-source" content="knative.dev/serving-operator     https://github.com/knative/serving-operator https://github.com/knative/serving-operator/tree/master{/dir} https://github.com/knative/serving-operator/blob/master{/dir}/{file}#L{line}">
-</head></html>

--- a/static/golang/website.html
+++ b/static/golang/website.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/website git https://github.com/knative/website">
+    <meta name="go-source" content="knative.dev/website     https://github.com/knative/website https://github.com/knative/website/tree/master{/dir} https://github.com/knative/website/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/wg-repository.html
+++ b/static/golang/wg-repository.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/wg-repository git https://github.com/knative-sandbox/wg-repository">
+    <meta name="go-source" content="knative.dev/wg-repository     https://github.com/knative-sandbox/wg-repository https://github.com/knative-sandbox/wg-repository/tree/master{/dir} https://github.com/knative-sandbox/wg-repository/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/tools/redir-gen/go.mod
+++ b/tools/redir-gen/go.mod
@@ -1,0 +1,5 @@
+module knative.dev/website/tools/redir-gen
+
+go 1.15
+
+require github.com/google/go-github/v32 v32.1.0

--- a/tools/redir-gen/go.sum
+++ b/tools/redir-gen/go.sum
@@ -1,0 +1,13 @@
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/tools/redir-gen/main.go
+++ b/tools/redir-gen/main.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+)
+
+var (
+	knativeOrgs   = []string{"knative", "knative-sandbox"}
+	allowedRepoRe = regexp.MustCompile("^[a-z][-a-z0-9]+$")
+)
+
+// repoInfo provides a simple holder for GitHub repo information needed to
+// generate go mod redirects.
+type repoInfo struct {
+	// Org is the name of the github organization the repo is in.
+	Org string
+	// Repo is the name of the github repo within the organizatiøon (e.g.
+	// "serving", NOT "knative/serving")
+	Repo string
+	// DefaultBranch is the name of the default branch. This will be changing
+	// from "master" to "main" over time.
+	DefaultBranch string
+}
+
+type riSlice []repoInfo
+
+func main() {
+	repos, err := fetchRepos(knativeOrgs)
+	if err != nil {
+		log.Fatal("Failed to fetch repos: ", err)
+	}
+	for _, repo := range repos {
+		if createGoGetFile(repo) != nil {
+			log.Fatalf("Unable to create go mod file for %s: %v", repo, err)
+		}
+	}
+	if appendRedirs(repos) != nil {
+		log.Fatal("Failed to write redir file: ", err)
+	}
+}
+
+func fetchRepos(orgs []string) ([]repoInfo, error) {
+	ctx := context.Background()
+	allRepos := riSlice{}
+	client := github.NewClient(nil)
+	for _, org := range orgs {
+		repos, _, err := client.Repositories.ListByOrg(ctx, org, nil)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range repos {
+			if !allowedRepoRe.MatchString(*r.Name) || *r.Archived {
+				continue
+			}
+			allRepos = append(allRepos, repoInfo{org, *r.Name, *r.DefaultBranch})
+		}
+	}
+	sort.Sort(allRepos)
+	return allRepos, nil
+}
+
+const (
+	goHTML = `<html><head>
+    <meta name="go-import" content="knative.dev/{{.Repo}} git https://github.com/{{.Org}}/{{.Repo}}">
+    <meta name="go-source" content="knative.dev/{{.Repo}}     https://github.com/{{.Org}}/{{.Repo}} https://github.com/{{.Org}}/{{.Repo}}/tree/{{.DefaultBranch}}{/dir} https://github.com/{{.Org}}/{{.Repo}}/blob/{{.DefaultBranch}}{/dir}/{file}#L{line}">
+</head></html>
+`
+	redirText = `/{{.Repo}}/* go-get=1 /golang/{{.Repo}}.html 200
+`
+
+	autogenPrefix = `
+# The following lines are AUTO-GENERATED
+#
+# DO NOT EDIT!
+#
+# To regenerate, run:
+`
+)
+
+func appendRedirs(ris []repoInfo) error {
+
+	redirFilename := "static/_redirects"
+	redirFile, err := os.OpenFile(redirFilename, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return fmt.Errorf("Unable to open %q: %w", redirFilename, err)
+	}
+	defer redirFile.Close()
+
+	redirs, err := ioutil.ReadAll(redirFile)
+	if err != nil {
+		return fmt.Errorf("Unable to read %q: %w", redirFilename, err)
+	}
+
+	seekTo := int64(strings.Index(string(redirs), autogenPrefix))
+	if seekTo == -1 {
+		seekTo = int64(len(redirs))
+	}
+	if _, err := redirFile.Seek(seekTo, 0); err != nil {
+		return fmt.Errorf("Unable to seek in %q: %w", redirFilename, err)
+	}
+	if redirFile.Truncate(seekTo) != nil {
+		return fmt.Errorf("Unable to truncate %q: %w", redirFilename, err)
+	}
+
+	if _, err := redirFile.WriteString(autogenPrefix); err != nil {
+		return fmt.Errorf("Unable to write to %q: %w", redirFilename, err)
+	}
+	if _, err := redirFile.WriteString(fmt.Sprintf("#   %s\n", strings.Join(os.Args, " "))); err != nil {
+		return fmt.Errorf("Unable to write to %q: %w", redirFilename, err)
+	}
+	for _, ri := range ris {
+		if redirTemplate.Execute(redirFile, ri) != nil {
+			return fmt.Errorf("Unable to write %s to %q: %w", ri.Repo, redirFilename, err)
+		}
+	}
+	return nil
+}
+
+var fileTemplate = template.Must(template.New("gohtml").Parse(goHTML))
+var redirTemplate = template.Must(template.New("redir").Parse(redirText))
+
+// createGoGetFile creates a static HTML file providing a knative.dev mapping
+// for the specified org and repo.
+func createGoGetFile(ri repoInfo) error {
+	filename := fmt.Sprintf("static/golang/%s.html", ri.Repo)
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return fileTemplate.Execute(file, ri)
+}
+
+func (ri repoInfo) String() string {
+	return ri.Org + "/" + ri.Repo
+}
+
+func (ris riSlice) Len() int {
+	return len(ris)
+}
+
+func (ris riSlice) Less(i, j int) bool {
+	return ris[i].Repo < ris[j].Repo
+}
+
+func (ris riSlice) Swap(i, j int) {
+	ris[i], ris[j] = ris[j], ris[i]
+
+}

--- a/tools/redir-gen/redirtemplate.gohtml
+++ b/tools/redir-gen/redirtemplate.gohtml
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/{{.Repo}} git https://github.com/{{.Org}}/{{.Repo}}">
+    <meta name="go-source" content="knative.dev/{{.Repo}}     https://github.com/{{.Org}}/{{.Repo}} https://github.com/{{.Org}}/{{.Repo}}/tree/master{/dir} https://github.com/{{.Org}}/{{.Repo}}/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
This generates a bunch more redirects than we have, standardizes the format, and I think fixes the sample-controller import.

I wasn't quite sure what effect putting a `go.mod` at the top-level would have, so put it next to the tool, but I'd like some opinions.

/assign @mattmoor @n3wscott @RichieEscarez 

Next step:
* Figure out how to run this as a nightly action proposing PRs.