### PR TITLE
Update build scripts to build from any named docs fork

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -166,6 +166,9 @@ else
 echo 'Staged content (unique to only this build) can be viewed at:' "$DEPLOY_URL"
 fi
 
+# Process the source files
+source scripts/processsourcefiles.sh
+
 # If from a WEBHOOK, show payload
 if [ "$WEBHOOK" = "true" ]
 then
@@ -173,9 +176,6 @@ then
   echo 'Webhook URL:' "$INCOMING_HOOK_URL"
   echo 'Webhook Body:' "$INCOMING_HOOK_BODY"
 fi
-
-# Process the source files
-source scripts/processsourcefiles.sh
 
 # BUILD MARKDOWN
 # Start HUGO build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,6 +28,7 @@ source scripts/docs-version-settings.sh
 # Use default repo and branch from docs-version-settings.sh
 BRANCH="$DEFAULTBRANCH"
 FORK="$DEFAULTREPO"
+REPO="$DEFAULTORG"
 
 # Set build default values
 BUILDENVIRONMENT="production"
@@ -56,8 +57,11 @@ while getopts f:b:a: arg; do
   case $arg in
     f)
       echo 'FORK:' "${OPTARG}"
-      # Set specified knative/docs repo fork
+      # The GitHub repo name of the knative/docs fork to builb.
+      # Example: myrepo/forkname
       FORK="${OPTARG}"
+      # Extract the repo name
+      REPO=$(echo "$FORK" | sed -e 's/\.*\/.*//')
       ;;
     b)
       echo 'BRANCH:' "${OPTARG}"

--- a/scripts/docs-version-settings.sh
+++ b/scripts/docs-version-settings.sh
@@ -16,4 +16,5 @@ NUMOFVERSIONS="3"
 OLDESTVERSION=$((LATESTVERSION-NUMOFVERSIONS))
 
 # An optional value that you can locally override for local builds/testing
-DEFAULTFORK="knative"
+DEFAULTORG="knative"
+DEFAULTREPO="$DEFAULTORG/docs"

--- a/scripts/localbuild.sh
+++ b/scripts/localbuild.sh
@@ -52,7 +52,7 @@ set -e
 source scripts/docs-version-settings.sh
 # Use default repo and branch from docs-version-settings.sh
 BRANCH="$DEFAULTBRANCH"
-FORK="$DEFAULTFORK"
+FORK="$DEFAULTREPO"
 
 # Set local build default values
 BUILDENVIRONMENT="local"
@@ -75,7 +75,7 @@ LIVERELOAD=" --watch=false --disableLiveReload"
 #
 #     USAGE: Append the -f repofork and/or the -b branchname to the command.
 #            Example:
-#                    ./scripts/build.sh -f repofork -b branchname -s
+#                    ./scripts/build.sh -f repofork -b branchname -s true
 #
 # (2) Run a complete local build of the knative.dev site. Clones all the content
 #     from knative/docs repo, including all branches.
@@ -105,9 +105,9 @@ LIVERELOAD=" --watch=false --disableLiveReload"
 #
 #    - Build content from specified fork and branch:
 #      - Build any branch from your fork or from someones in a PR
-#      ./scripts/localbuild.sh -f REPOFORK -b BRANCHNAME
+#      ./scripts/localbuild.sh -f REPO/FORK -b BRANCHNAME
 #
-#    - Locally build a specific branch from $FORK ($DEFAULTFORK):
+#    - Locally build a specific branch from knative/docs:
 #      ./scripts/localbuild.sh -b BRANCHNAME
 #
 #    - Combine other -s or -a flags. Example:
@@ -119,7 +119,8 @@ while getopts "f:b:a:s:" arg; do
 	  echo '--- BUILDING FROM ---'
       echo 'FORK:' "${OPTARG}"
       # Build remote content locally
-      # Set the GitHub repo name of your knative/docs fork you want built.
+      # Set the GitHub repo name of your knative/docs fork that you want built.
+      # Example: myrepo/forkname
       FORK="${OPTARG}"
       # Retrieve content from remote repo
       BUILDSINGLEBRANCH="true"

--- a/scripts/localbuild.sh
+++ b/scripts/localbuild.sh
@@ -53,6 +53,7 @@ source scripts/docs-version-settings.sh
 # Use default repo and branch from docs-version-settings.sh
 BRANCH="$DEFAULTBRANCH"
 FORK="$DEFAULTREPO"
+REPO="$DEFAULTORG"
 
 # Set local build default values
 BUILDENVIRONMENT="local"
@@ -124,6 +125,8 @@ while getopts "f:b:a:s:" arg; do
       FORK="${OPTARG}"
       # Retrieve content from remote repo
       BUILDSINGLEBRANCH="true"
+      # Extract the repo name
+      REPO=$(echo "$FORK" | sed -e 's/\.*\/.*//')
       ;;
     b)
       echo 'USING BRANCH:' "${OPTARG}"
@@ -134,7 +137,7 @@ while getopts "f:b:a:s:" arg; do
       BUILDSINGLEBRANCH="true"
       ;;
     a)
-      echo 'BUILDING ALL RELEASES FROM KNATIVE/DOCS'
+      echo 'BUILDING ALL RELEASES FROM' "$FORK"
       # If 'true', all knative/docs branches are built to mimic a
       # "production" build.
       # REQUIRED: If you specify a fork ($FORK), all of the same branches

--- a/scripts/localbuild.sh
+++ b/scripts/localbuild.sh
@@ -15,7 +15,7 @@ set -e
 #    2. Add it to your `PATH`. For example, add the following line to your `~/.bash_profile`:
 #      `PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"`
 #
-# 3. Optional: Install PostCSS if you want to change the sites CSS and need to build those changes locally.
+# 3. Install PostCSS. Needed to build the site locally.
 #    https://www.docsy.dev/docs/getting-started/#install-postcss
 #
 # 4. Clone the knative/docs repo:
@@ -24,10 +24,18 @@ set -e
 # 5. Clone the knative/website repo, including the Docsy theme submodule:
 #    `git clone --recurse-submodules https://github.com/knative/website.git`
 #
-# 6. From the root of the knative/website clone, run:
+#     Note: These repos must be cloned into the same folder and use the same
+#     names ('docs', 'website', 'community')
+#
+# 6. Optional: Clone the knative/community repo.
+#    `git clone https://github.com/knative/community.git`
+#
+# 7. From the root of the knative/website clone, run:
 #    `scripts/localbuild.sh`
 #
-# 7. If you change content in your knative/docs repo clone, you rebuild your local
+#     See all command options below (ie. build from your remote fork, etc).
+#
+# 8. If you change content in your knative/docs repo clone, you rebuild your local
 #    site by stopping the localhost (CTRL C) and running `scripts/localbuild.sh` again.
 #
 # By default, the command locally runs a Hugo build of using your local knative/website and
@@ -51,6 +59,7 @@ BUILDENVIRONMENT="local"
 BUILDALLRELEASES="false"
 BUILDSINGLEBRANCH="false"
 PRBUILD="false"
+LOCALBUILD="true"
 
 # Default Hugo build options
 # disable Hugo server

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -84,7 +84,8 @@ then
   # Check if $FORK includes the /community branch (remote and PR builds)
   if ! (git ls-remote --quiet git@github.com:"$REPO"/community.git)
   then
-    echo 'No /community fork found in' "$REPO" '- building from the master branch of' "$DEFAULTORG"
+    echo 'No /community fork found in' "$REPO"
+    echo 'Building from the master branch of' "$DEFAULTORG"'/community'
     # Default to knative/community
     git clone --quiet -b master https://github.com/"$DEFAULTORG"/community.git temp/community
   else

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -17,32 +17,32 @@ then
 # Full build for knative.dev (config/production). Contributors can also use this for personal builds.
   echo '------ BUILDING ALL DOCS BRANCHES/RELEASES ------'
   # Build Knative docs from:
-  # - https://github.com/"$FORK"/docs
-  # - https://github.com/knative/community
+  # - https://github.com/"$FORK"
+  # - https://github.com/"$REPO"/community
 
-  # Build all branches (assumes $FORK contains all docs versions)
+  # Build all branches (assumes $FORK contains all docs branches)
   echo '------ Cloning Community and Pre-release docs (master) ------'
   # MASTER
-  echo 'Getting blog posts and community owned samples from knative/docs master branch'
-  git clone --quiet -b master https://github.com/"$FORK"/docs.git content/en
+  echo 'Getting blog posts and community owned samples from the master branch of' "$FORK"
+  git clone --quiet -b master https://github.com/"$FORK".git content/en
   echo 'Getting pre-release development docs from master branch'
   # Move "pre-release" docs content into the 'development' folder:
   mv content/en/docs content/en/development
   # DOCS BRANCHES
   echo '------ Cloning all docs releases ------'
-  # Get versions of released docs from their branches in "$FORK"/docs
+  # Get versions of released docs from their branches in "$FORK"
   # Versions are defined in website/scripts/docs-version-settings.sh
   # If this is a PR build, then build that content as the latest release (assume PR preview builds are always from "latest")
-  echo 'Getting the archived docs releases from branches in:' "$FORK"'/docs'
+  echo 'Getting the archived docs releases from branches in:' "$FORK"
   r=$OLDESTVERSION
   while [[ $r -le $LATESTVERSION ]]
   do
     CLONE="temp/release-0.${r}"
     echo 'Getting docs from: release-0.'"${r}"
-    git clone --quiet -b "release-0.${r}" "https://github.com/${FORK}/docs.git" "$CLONE"
+    git clone --quiet -b "release-0.${r}" "https://github.com/${FORK}.git" "$CLONE"
     if [ "$r" = "$LATESTVERSION" ]
     then
-      echo 'The /docs/ section is built from:' "$FORK"'/release-0.'"${r}"
+      echo 'The /docs/ section is built from the' '/release-0.'"${r}" 'branch of' "$FORK"
       mv "$CLONE"/docs content/en/docs
     else
       # Only use the "docs" folder from all branches/releases
@@ -57,8 +57,8 @@ then
 # SINGLE REMOTE BRANCH BUILD
 # Build only the content from $FORK and $BRANCH
   echo '------ BUILDING SINGLE REMOTE BRANCH ------'
-  echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"'/docs'
-  git clone --quiet -b "$BRANCH" https://github.com/"$FORK"/docs.git content/en
+  echo 'The /docs/ section is built from the' "$BRANCH" 'branch of' "$FORK"
+  git clone --quiet -b "$BRANCH" https://github.com/"$FORK".git content/en
   LOCALBUILD="false"
 else
 # DEFAULT: LOCAL BUILD
@@ -82,15 +82,15 @@ then
   echo ' - ----- Cloning contributor docs ------'
   echo 'Getting Knative community and contributor guidelines'
   # Check if $FORK includes the /community branch (remote and PR builds)
-  if ! (git ls-remote --quiet git@github.com:"$FORK"/community.git)
+  if ! (git ls-remote --quiet git@github.com:"$REPO"/community.git)
   then
-    echo 'No /community fork found in' "$FORK" '- building from the master branch of' "$DEFAULTFORK"
+    echo 'No /community fork found in' "$REPO" '- building from the master branch of' "$DEFAULTORG"
     # Default to knative/community
-    git clone --quiet -b master https://github.com/"$DEFAULTFORK"/community.git temp/community
+    git clone --quiet -b master https://github.com/"$DEFAULTORG"/community.git temp/community
   else
   # Build /community from the remote fork
-    echo 'Building from the master branch of' "$FORK"'/community'
-    git clone --quiet -b master https://github.com/"$FORK"/community.git temp/community
+    echo 'Building from the master branch of' "$REPO"'/community'
+    git clone --quiet -b master https://github.com/"$REPO"/community.git temp/community
   fi
   # Move files into existing "contributing" folder
   mv temp/community/* content/en/community/contributing


### PR DESCRIPTION
All knative/docs PRs get automatically built into preview sites here: https://app.netlify.com/sites/knative/deploys

The first build scripts made many assumptions to get all things working / up-and-running.

These changes add the following enhancements:

- Forks can be renamed and no longer must match the knative repo`/docs` (`richieescarez/docs`). Example: `ricardozanini/knative-docs`

- A fork of knative/community is optional. Build will default to the `master` branch of knative/community.

- Moved the Build Details closer to the top of the build logs to make it easier to locate the `PR#`

![image](https://user-images.githubusercontent.com/11762685/101449278-55012b80-38dd-11eb-9ff8-246a21c85501.png)
