### PR TITLE
Add net-ingressv2 golang redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -44,6 +44,7 @@
 /net-contour/* go-get=1 /golang/net-contour.html 200
 /net-http01/* go-get=1 /golang/net-http01.html 200
 /net-istio/* go-get=1 /golang/net-istio.html 200
+/net-ingressv2/* go-get=1 /golang/net-ingressv2.html 200
 /net-kourier/* go-get=1 /golang/net-kourier.html 200
 /networking/* go-get=1 /golang/networking.html 200
 /operator/* go-get=1 /golang/operator.html 200

--- a/static/golang/net-ingressv2.html
+++ b/static/golang/net-ingressv2.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/net-ingressv2 git https://github.com/knative-sandbox/net-ingressv2">
+    <meta name="go-source" content="knative.dev/net-ingressv2     https://github.com/knative-sandbox/net-ingressv2 https://github.com/knative-sandbox/net-ingressv2/tree/master{/dir} https://github.com/knative-sandbox/net-ingressv2/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
# Changes

As per title, this patch adds net-ingressv2 to golang redirect.

Please also refer to https://github.com/knative/community/issues/389

/kind enhancement

**Release Note**

```release-note
NONE
```

/cc @tcnghia @ZhiminXiang 
