### PR TITLE
Adding a link to katacoda tutorials

### DIFF
--- a/content-override/en/_index.html
+++ b/content-override/en/_index.html
@@ -19,6 +19,9 @@ title = "Knative"
 			<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/knative">
 				View Repository <i class="fab fa-github ml-2 "></i>
 			</a>
+			<a class="btn btn-lg btn-primary mr-3 mb-4" href="https://www.katacoda.com/knative-tutorials">
+				Try in Browser <i class="fas fa-laptop ml-2"></i>
+			</a>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
<img width="1670" alt="Screen Shot 2021-01-12 at 9 50 22 PM" src="https://user-images.githubusercontent.com/1129281/104493346-c3df3d80-5589-11eb-88de-58630792ca18.png">

This links to the katacoda tutorials that are pending merge:
https://github.com/knative/docs/pull/3142