### PR TITLE
add version 0.20.0 to docs build

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,7 +8,7 @@
 # GitHub branch (latest release)
 latest_github_branch = "release-0.17"
 # Default version (latest release)
-version = "v0.19"
+version = "v0.20"
 ########################
 
 # Section labels for versions

--- a/config/local/params.toml
+++ b/config/local/params.toml
@@ -17,7 +17,7 @@ releaselabel = "Local Preview Build: "
 # Set to "docs" path
 # RELEASE-ITEM: 'version' gets updated each release
 [[versions]]
-  version = "v0.19"
+  version = "v0.20"
   ghbranchname = "master"
   url = "/docs/"
   dirpath = "docs"

--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -39,8 +39,8 @@ no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues
 # Set to "docs" path
 
 [[versions]]
-  version = "v0.19"
-  ghbranchname = "release-0.19"
+  version = "v0.20"
+  ghbranchname = "release-0.20"
   url = "/docs/"
   dirpath = "docs"
 
@@ -49,6 +49,11 @@ no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues
 ###################
 # Prefix all past versions with release # "v#.#-docs"
 
+[[versions]]
+  version = "v0.19"
+  ghbranchname = "release-0.16"
+  url = "/v0.19-docs/"
+  dirpath = "v0.19-docs"
 [[versions]]
   version = "v0.18"
   ghbranchname = "release-0.18"
@@ -59,11 +64,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/knative/docs/issues
   ghbranchname = "release-0.17"
   url = "/v0.17-docs/"
   dirpath = "v0.17-docs"
-[[versions]]
-  version = "v0.16"
-  ghbranchname = "release-0.16"
-  url = "/v0.16-docs/"
-  dirpath = "v0.16-docs"
 
 [[versions]]
   version = "Archives"

--- a/config/staging/params.toml
+++ b/config/staging/params.toml
@@ -16,7 +16,7 @@ releaselabel = "Pull Request Preview: "
 # Set PRs to build to the "docs" path
 # RELEASE-ITEM: 'version' gets updated each release
 [[versions]]
-  version = "v0.19"
+  version = "v0.20"
   ghbranchname = "master"
   url = "/docs/"
   dirpath = "docs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
 # Update to the latest version number
 # Enable permanent links to a new release (so links persist after release is archived)
 [[redirects]]
-  from = "/v0.19-docs/*"
+  from = "/v0.20-docs/*"
   to = "/docs/:splat"
   status = 200
 
@@ -29,6 +29,11 @@
 # We publish LATEST -3 versions to knative.dev, all older versions get redirect
 # back to the latest version in case old bookmarks or articles still point to
 # one of those "previously published" versions
+
+[[redirects]]
+  from = "/v0.16-docs/*"
+  to = "/docs/"
+  status = 301
 
 [[redirects]]
   from = "/v0.15-docs/*"

--- a/scripts/docs-version-settings.sh
+++ b/scripts/docs-version-settings.sh
@@ -6,7 +6,7 @@
 
 # Version number of the latest release
 # RELEASE-ITEM: This gets updated every release
-LATESTVERSION="19"
+LATESTVERSION="20"
 
 # Branch name of the latest release
 DEFAULTBRANCH="release-0.$LATESTVERSION"


### PR DESCRIPTION
Add Serving and Eventing v0.20.0 to the docs build and publish it as the latest release in the Knative website