### PR TITLE
Enlarge nav text

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -18,7 +18,7 @@
 
     a {
         display: block;
-        font-weight: $font-weight-light;
+        font-weight: $font-weight-normal;
         padding-bottom: .25rem;
     }
 

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -40,7 +40,7 @@
 
     &__section-title {
         display: block;
-        font-weight: $font-weight-light;
+        font-weight: $font-weight-normal;
 
         .active {
             color: $gray-900;
@@ -57,7 +57,7 @@
 
         &__page {
             color: $gray-700;
-            font-weight: $font-weight-light;
+            font-weight: $font-weight-normal;
         }
     }
 


### PR DESCRIPTION
Update scss so that the text of the nav menu is the same size as the page body

fixes https://github.com/knative/docs/issues/3042