### PR TITLE
Redirect contributing URL to the docs website

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
 /community/contributing/working-groups /community/contributing/working-groups/working-groups 301
+/community/contributing/docs/docs-contributing https://github.com/knative/docs/tree/master/CONTRIBUTING.md 301
 
 # The following lines are AUTO-GENERATED
 #


### PR DESCRIPTION
Add redirect to assuage Richie's concerns about bookmarks to https://knative.dev/community/contributing/docs/docs-contributing/ in https://github.com/knative/docs/pull/3269#issuecomment-786838046