### PR TITLE
Remove README->index renames

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -23,12 +23,6 @@
     {{ $.Scratch.Set "filepath" (replaceRE "contributing\\/" "" (printf "%s" ($.Scratch.Get "filepath"))) }}
   {{ end }}
 
-  {{/* Open to the README.md in github repo */}}
-  {{ if in (printf "%s" .File) "index.md" }}
-    {{ $.Scratch.Set "filepath" (replaceRE "_index" "README" ($.Scratch.Get "filepath")) }}
-    {{ $.Scratch.Set "filepath" (replaceRE "index" "README" ($.Scratch.Get "filepath")) }}
-  {{ end }}
-
   {{/* Find the github branch for the corresponding docs version otherwise set to master */}}
   {{ if in $pageSection "docs" }}
     {{ range .Site.Params.versions }}

--- a/scripts/processsourcefiles.sh
+++ b/scripts/processsourcefiles.sh
@@ -179,7 +179,7 @@ find . -type f -path '*/content/*/*/*' -name 'README.md' \
      ! -path '*/contributing/*' ! -path '*/v0.6-docs/*' ! -path '*/v0.5-docs/*' \
      ! -path '*/v0.4-docs/*' ! -path '*/v0.3-docs/*' ! -path '*/.github/*' ! -path '*/hack/*' \
      ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' \
-    -execdir bash -c 'if [ -e _index.md -o -e index.md ]; then echo "_index.md exists - skipping ${PWD#*/}"; else mv "$1" "${1/\README/\index}"; fi' -- {} \;
+    -execdir bash -c 'if ! [ -e _index.md -o -e index.md ]; then echo "BARE README AT ${PWD#*/}, WILL NOT BE RENDERED."; fi' -- {} \;
 
 # GET HANDCRAFTED SITE LANDING PAGE
 echo 'Copying the override files into the /content/ folder'


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🧹  Remove renames of `README.md` to `_index.md` or `index.md`. Instead, just report in the build script if this happens, so we can clean them up. Simplifies the build process and makes it easier to (for example) just build directly from the sources instead of needing additional pre-processing.
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/knative/docs/pull/3286
Fixes #230 

<!-- Please include the 'why' behind your changes if no issue exists -->