### PR TITLE
Fix/update missed release parameter

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -6,7 +6,7 @@
 # RELEASE-ITEM: 'latest_github_branch' and 'version' get updated each release
 
 # GitHub branch (latest release)
-latest_github_branch = "release-0.17"
+latest_github_branch = "release-0.21"
 # Default version (latest release)
 version = "v0.21"
 ########################


### PR DESCRIPTION
This value exists as a "default/fallback" value and is used in the [right-side nav menu](https://github.com/knative/website/blob/b5405bb4472f67de3b330b9a994856928a10aade/layouts/partials/page-meta-links.html#L8) and the [branch shortcode](https://github.com/knative/website/blob/e4f08e31114d6df602e9a5d70e3d7d7f91891a2a/layouts/shortcodes/branch.md):

https://knative.dev/docs/smoketest/#install-version-numbers-and-clone-branch-commands