### PR TITLE
Add Google Analytics tracking ID

### DIFF
--- a/config/production/params.toml
+++ b/config/production/params.toml
@@ -6,6 +6,10 @@
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "008069654339966445896:nqydaxfpl7a"
 
+# Google Analytics for Knative
+# Used in layouts/partials/google_analytics_knative.html to add second tracking ID
+googleAnalyticsKnative = "G-YRMNFYE32R"
+
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,

--- a/layouts/partials/google_analytics_knative.html
+++ b/layouts/partials/google_analytics_knative.html
@@ -1,0 +1,53 @@
+<!-- custom copy of https://github.com/gohugoio/hugo/blob/ba16a14c6e884e309380610331aff78213f84751/tpl/tplimpl/embedded/templates/google_analytics.html -->
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+<!-- Modified the following line to use parameter at config/production/params.toml -->
+{{- if not $pc.Disable }}{{ with .Site.Params.GoogleAnalyticsKnative -}}
+{{ if hasPrefix . "G-"}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+}
+</script>
+{{ else if hasPrefix . "UA-" }}
+<script type="application/javascript">
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  {{- if $pc.UseSessionStorage }}
+  if (window.sessionStorage) {
+    var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+    ga('create', '{{ . }}', {
+      'storage': 'none',
+      'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+     });
+     ga(function(tracker) {
+      sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+     });
+   }
+  {{ else }}
+  ga('create', '{{ . }}', 'auto');
+  {{ end -}}
+  {{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+  ga('send', 'pageview');
+}
+</script>
+{{- end -}}
+{{- end }}{{- end -}}
+
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,6 +1,9 @@
 <meta name="google-site-verification" content="knbzameE514X1-2MyT4a18Bzc49Jbzdd7NipLte_9A8" />
 <!-- Webmaster Central ownership verification using "HTML tag" method -->
 <!-- https://www.google.com/webmasters/verification/details?hl=en&siteUrl=http://knative.dev/ -->
+
+{{ partial "google_analytics_knative.html" . }}
+
 <script src="/js/cookie-consent.js"></script>
 <script src="/js/script.js"></script>
 

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -2,6 +2,7 @@
 <!-- Webmaster Central ownership verification using "HTML tag" method -->
 <!-- https://www.google.com/webmasters/verification/details?hl=en&siteUrl=http://knative.dev/ -->
 
+{{ template "_internal/google_analytics.html" . }}
 {{ partial "google_analytics_knative.html" . }}
 
 <script src="/js/cookie-consent.js"></script>


### PR DESCRIPTION
New partial and parameter that uses a copied version of the Hugo internal file used to add first ID. 

Given the [built in functionality in Hugo (for a single ID only)](https://gohugo.io/templates/internal/#google-analytics) and to allow all the dependencies Hugo built in to continue working, the second ID is added using its own partial (a modified version of the same "built-in" internal GA feature).

Context: 
- https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers?hl=en#working_with_multiple_trackers
- https://support.google.com/analytics/answer/9744165?hl=en&ref_topic=9303319#zippy=%2Cadd-your-tag-directly-to-your-web-pages

fixes #253 