### PR TITLE
Add future Docs release owners as Approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,6 +7,8 @@ aliases:
   - mattmoor
   - tcnghia
   - vaikas
+  - csantanapr
+  - omerbensaadon
 
   docs-approvers:
   - carieshmarie


### PR DESCRIPTION
Add @csantanapr and @omerbensaadon to docs approvers list to ensure they are not blocked in the future, especially when cutting docs releases.