### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eng-approvers
-- docs-approvers
+- technical-oversight-committee
+- ux-writers
+- docs-writers
 reviewers:
-- docs-approvers
+- docs-writers
+- docs-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,16 +1,22 @@
 aliases:
-  eng-approvers:
-  - averikitsch
+  technical-oversight-committee:
   - evankanderson
   - grantr
   - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vaikas
+  - rhuss
+
+  ux-writers:
   - csantanapr
   - omerbensaadon
 
-  docs-approvers:
-  - carieshmarie
+  docs-writers:
   - abrennan89
+  - carieshmarie
   - richieescarez
+
+  docs-reviewers:
+  - RichardJJG
+  - jonatasbaldin
+  - mpetason
+  - omerbensaadon
+  - snneji


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
