### PR TITLE
Redirect serving spec to specs repo

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,6 @@
 /community/contributing/working-groups /community/contributing/working-groups/working-groups 301
 /community/contributing/docs/docs-contributing https://github.com/knative/docs/tree/main/CONTRIBUTING.md 301
+/docs/serving/spec/knative-api-specification-1.0 https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md
 
 # The following lines are AUTO-GENERATED
 #


### PR DESCRIPTION
Fix existing links to Knative serving spec; in particular, I've given out a lot of references to the error handling component.

# Changes

- Adds a redirect for the serving spec
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup
