### PR TITLE
Enable asciidoctor in Netlify builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'asciidoctor'

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -25,7 +25,11 @@ ignoreFiles = [
   "/*/reference/api/eventing/eventing-contrib.md",
   "/*/reference/serving.md",
   "/*/reference/eventing/eventing.md",
-  "/*/reference/eventing/eventing-contrib.md" ]
+  "/*/reference/eventing/eventing-contrib.md",
+  "/community/contributing/elections/.*",
+  "/community/contributing/hack/.*",
+  "/community/contributing/mechanics/tools/.*",
+  "/community/contributing/peribolos/.*" ]
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
 theme = ["docsy"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,9 @@
 # Quit on error
 set -e
 
+# Install asciidoctor via RubyGems
+bundle
+
 # Retrieve the default docs version
 source scripts/docs-version-settings.sh
 # Use default repo and branch from docs-version-settings.sh


### PR DESCRIPTION
Based on https://patrickpeeters.com/2019/09/asciidoc-support-for-hugo-on-netlify/; this seemed easy enough to do that it might be worth having in our back pocket for experimentation.
