### PR TITLE
Add fallback redirects to Go docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -129,3 +129,10 @@
   from = "/development/*"
   to = "https://dev-knative.netlify.app/development/"
   status = 302
+
+#################
+# Finally, fallback to Go docs
+[[redirects]]
+  from = "*"
+  to = "https://pkg.go.dev/*"
+  status = 200


### PR DESCRIPTION
# Changes

Add a redirect rule as the final rule that will redirect user to Go docs under https://go.pkg.dev, so that for instance https://knative.dev/eventing would result in https://pkg.go.dev/knative.dev/eventing

I'm a little worried that this will result in users getting 404s from pkg.go.dev instead of the current Netlify 404 page, but it's kinda 6 of one half dozen of the other.