### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+**DEPRECATED:** active development of most of the knative website now takes place in the [`knative/docs`](https://github.com/knative/docs) repo. The `website` repo is still used to generate certain sections of the website, but is being transitioned away from (at which point this repository will be archived). In almost all cases, changes should now be made via [`knative/docs`](https://github.com/knative/docs).
+
 # Knative Website
 
-This repo contains the [hugo](https://gohugo.io) templates, formatting, and themes for the
+This repo contains the [hugo](https://gohugo.io) templates, formatting, and themes for the community and blog sections of the
 Knative website.
 
 The actual content for the website is found on the [`knative/docs`](https://github.com/knative/docs) repo. To add or make content changes, please start with the [Knative contributor's guide](https://knative.dev/docs/help/contributor/).


### PR DESCRIPTION
Adds deprecation notice since all development should now take place in `docs/` (this repo will be archive once we transition community and blog over).